### PR TITLE
Let the hugo container create and serve files with host users groupid

### DIFF
--- a/factcast-site/documentation/serve.sh
+++ b/factcast-site/documentation/serve.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 (
-docker run --rm -u `id -u` -p 1313:1313 -v $PWD:/srv/hugo yanqd0/hugo hugo server -w --bind 0.0.0.0
+docker run --rm -u `id -u`:`id -g` -p 1313:1313 -v $PWD:/srv/hugo yanqd0/hugo hugo server -w --bind 0.0.0.0
 )
 


### PR DESCRIPTION
The "resources" folder is created for "root" group otherwise.