### PR TITLE
#884: Publish docker image during release

### DIFF
--- a/factcast-docker/pom.xml
+++ b/factcast-docker/pom.xml
@@ -104,4 +104,32 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>oss.push-docker-image</id>
+      <activation>
+        <property>
+          <name>ossrh</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.spotify</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
+            <configuration>
+              <pushImage>true</pushImage>
+              <imageTags>
+                <imageTag>${project.version}</imageTag>
+              </imageTags>
+              <pushImageTag>true</pushImageTag>
+              <serverId>docker-hub</serverId>
+              <registryUrl>https://index.docker.io/v1/</registryUrl>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
To make this work you have to add an additonal server to the mvn settings of the release machine.  
 Something like
```
  <server>
    <id>docker-hub</id>
    <username>foo</username>
    <password>secret-password</password>
    <configuration>
      <email>foo@foo.bar</email>
    </configuration>
  </server>
```

Closes #884 