### PR TITLE
Issue941 - Implement Keepalive roundtrip to detect stale postgres listeners

### DIFF
--- a/factcast-site/documentation/content/setup/properties.md
+++ b/factcast-site/documentation/content/setup/properties.md
@@ -29,6 +29,9 @@ Properties you can use to configure Factcast:
 | factcast.store.pgsql.inMemTransformationCacheCapacity |  when using the inmem impl of the transformation cache, this is the max number of entries cached. The minimum value here is 1000. | 1_000_000 
 | factcast.store.pgsql.deleteTransformationsStaleForDays |  when using the persistent impl of the transformation cache, this is the min number of days a transformation result is not read in order to be considered stale. This should free some space in a regular cleanup job | 14  
 |factcast.store.pgsql.transformationCacheCompactCron|defines the cron schedule for compacting the transformation result cache | `0 0 0 * * *` (at midnight)
+|factcast.store.pgsql.factNotificationBlockingWaitTimeInMillis| Controls how long to block waiting for new notifications from the database (Postgres LISTEN/ NOTIFY mechanism). When this time exceeds the notifications is repeated | 15000 (15sec)
+|factcast.store.pgsql.factNotificationMaxRoundTripLatencyInMillis| When Factcast did not receive any notifications after factNotificationBlockingWaitTimeInMillis milliseconds it validates the health of the database connection. For this purpose it sends an internal notification to the database and waits for the given time to receive back an answer. If the time is exceeded the database connection is renewed | 200
+|factcast.store.pgsql.factNotificationNewConnectionWaitTimeInMillis| how much time to wait between invalidating and acquiring a new connection. note: This parameter is only applied in the part of Factcast which deals with receiving and forwarding database notifications | 100
 
 
 

--- a/factcast-store-pgsql/src/main/java/org/factcast/store/pgsql/PgConfigurationProperties.java
+++ b/factcast-store-pgsql/src/main/java/org/factcast/store/pgsql/PgConfigurationProperties.java
@@ -116,6 +116,32 @@ public class PgConfigurationProperties implements ApplicationListener<Applicatio
      */
     boolean allowUnvalidatedPublish = false;
 
+    /**
+     * Controls how long to block waiting for new notifications from the
+     * database (Postgres LISTEN/ NOTIFY mechanism). When this time exceeds the
+     * health of the database connection is checked. After that waiting for new
+     * notifications is repeated.
+     */
+    int factNotificationBlockingWaitTimeInMillis = 1000 * 15;
+
+    /**
+     * When Factcast did not receive any notifications after
+     * factNotificationBlockingWaitTimeInMillis milliseconds it validates the
+     * health of the database connection. For this purpose it sends an internal
+     * notification to the database and waits for the given time to receive back
+     * an answer.
+     *
+     * If the time is exceeded the database connection is renewed.
+     */
+    int factNotificationMaxRoundTripLatencyInMillis = 200;
+
+    /**
+     * How much time to wait between invalidating and acquiring a new
+     * connection. Note: This parameter is only applied in the part of Factcast
+     * which deals with receiving and forwarding database notifications.
+     */
+    int factNotificationNewConnectionWaitTimeInMillis = 100;
+
     public int getFetchSize() {
         return getQueueSize() / queueFetchRatio;
     }

--- a/factcast-store-pgsql/src/main/java/org/factcast/store/pgsql/internal/CondensedQueryExecutor.java
+++ b/factcast-store-pgsql/src/main/java/org/factcast/store/pgsql/internal/CondensedQueryExecutor.java
@@ -75,8 +75,7 @@ class CondensedQueryExecutor {
                         try {
                             CondensedQueryExecutor.this.runTarget();
                         } catch (Throwable e) {
-                            log.debug("Scheduled query failed, closing: {}", e.getMessage());
-                            // TODO needed?
+                            log.error("Scheduled query failed, closing: {}", e.getMessage());
                         }
                     }
                 }, maxDelayInMillis);
@@ -91,7 +90,7 @@ class CondensedQueryExecutor {
     }
 
     @SuppressWarnings("WeakerAccess")
-    protected void runTarget() {
+    protected synchronized void runTarget() {
         try {
             target.run(false);
         } catch (Throwable e) {

--- a/factcast-store-pgsql/src/main/java/org/factcast/store/pgsql/internal/PgConstants.java
+++ b/factcast-store-pgsql/src/main/java/org/factcast/store/pgsql/internal/PgConstants.java
@@ -15,6 +15,8 @@
  */
 package org.factcast.store.pgsql.internal;
 
+import java.lang.management.ManagementFactory;
+
 import lombok.AccessLevel;
 import lombok.Generated;
 import lombok.experimental.FieldDefaults;
@@ -110,6 +112,13 @@ public class PgConstants {
             + COLUMN_HEADER + " @> ?::jsonb";
 
     public static final String LISTEN_SQL = "LISTEN " + CHANNEL_NAME;
+
+    public static final String ROUNDTRIP_CHANNEL_NAME = ManagementFactory.getRuntimeMXBean()
+            .getName();
+
+    public static final String NOTIFY_ROUNDTRIP = "NOTIFY " + ROUNDTRIP_CHANNEL_NAME;
+
+    public static final String LISTEN_ROUNDTRIP_CHANNEL_SQL = "LISTEN " + ROUNDTRIP_CHANNEL_NAME;
 
     public static final String UPDATE_FACT_SERIALS = "update " + TABLE_FACT + " set "
             + COLUMN_HEADER + "= jsonb_set( "

--- a/factcast-store-pgsql/src/main/java/org/factcast/store/pgsql/internal/PgFactStoreInternalConfiguration.java
+++ b/factcast-store-pgsql/src/main/java/org/factcast/store/pgsql/internal/PgFactStoreInternalConfiguration.java
@@ -15,9 +15,7 @@
  */
 package org.factcast.store.pgsql.internal;
 
-import java.sql.Connection;
 import java.util.concurrent.Executors;
-import java.util.function.Predicate;
 
 import javax.sql.DataSource;
 
@@ -112,8 +110,8 @@ public class PgFactStoreInternalConfiguration {
 
     @Bean
     public PgListener pgListener(@NonNull PgConnectionSupplier pgConnectionSupplier,
-            @NonNull EventBus eventBus, @NonNull Predicate<Connection> predicate) {
-        return new PgListener(pgConnectionSupplier, eventBus);
+            @NonNull EventBus eventBus, @NonNull PgConfigurationProperties props) {
+        return new PgListener(pgConnectionSupplier, eventBus, props);
     }
 
     @Bean

--- a/factcast-store-pgsql/src/main/java/org/factcast/store/pgsql/internal/PgFactStoreInternalConfiguration.java
+++ b/factcast-store-pgsql/src/main/java/org/factcast/store/pgsql/internal/PgFactStoreInternalConfiguration.java
@@ -113,7 +113,7 @@ public class PgFactStoreInternalConfiguration {
     @Bean
     public PgListener pgListener(@NonNull PgConnectionSupplier pgConnectionSupplier,
             @NonNull EventBus eventBus, @NonNull Predicate<Connection> predicate) {
-        return new PgListener(pgConnectionSupplier, eventBus, predicate);
+        return new PgListener(pgConnectionSupplier, eventBus);
     }
 
     @Bean

--- a/factcast-store-pgsql/src/main/java/org/factcast/store/pgsql/internal/listen/PgListener.java
+++ b/factcast-store-pgsql/src/main/java/org/factcast/store/pgsql/internal/listen/PgListener.java
@@ -104,7 +104,7 @@ public class PgListener implements InitializingBean, DisposableBean {
                         }
 
                         if (Arrays.stream(notifications)
-                                .anyMatch(n -> n.getName().equals(PgConstants.CHANNEL_NAME))) {
+                                .anyMatch(n -> PgConstants.CHANNEL_NAME.equals(n.getName()))) {
                             log.trace("notifying consumers for '{}'", PgConstants.CHANNEL_NAME);
                             postEvent(PgConstants.CHANNEL_NAME);
                         } else {

--- a/factcast-store-pgsql/src/main/java/org/factcast/store/pgsql/internal/listen/PgListener.java
+++ b/factcast-store-pgsql/src/main/java/org/factcast/store/pgsql/internal/listen/PgListener.java
@@ -15,14 +15,12 @@
  */
 package org.factcast.store.pgsql.internal.listen;
 
-import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Predicate;
 
 import org.factcast.store.pgsql.internal.PgConstants;
 import org.postgresql.PGNotification;
@@ -58,10 +56,6 @@ public class PgListener implements InitializingBean, DisposableBean {
 
     @NonNull
     final EventBus eventBus;
-
-    // TODO check if we can get rid of this now
-    @NonNull
-    final Predicate<Connection> pgConnectionTester;
 
     private final AtomicBoolean running = new AtomicBoolean(true);
 

--- a/factcast-store-pgsql/src/main/java/org/factcast/store/pgsql/internal/listen/PgListener.java
+++ b/factcast-store-pgsql/src/main/java/org/factcast/store/pgsql/internal/listen/PgListener.java
@@ -18,6 +18,7 @@ package org.factcast.store.pgsql.internal.listen;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -50,6 +51,8 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class PgListener implements InitializingBean, DisposableBean {
 
+    private static final int MAX_ALLOWED_NOTIFICATION_LATENCY_IN_MILLIS = 200;
+
     @NonNull
     final PgConnectionSupplier pgConnectionSupplier;
 
@@ -63,42 +66,51 @@ public class PgListener implements InitializingBean, DisposableBean {
 
     private Thread listenerThread;
 
-    private final int blockingWaitTimeInMillis = 1000 * 60;
+    private final int blockingWaitTimeInMillis = 1000 * 15;
 
     private void listen() {
         log.trace("Starting instance Listener");
         CountDownLatch l = new CountDownLatch(1);
         listenerThread = new Thread(() -> {
             while (running.get()) {
+
+                // new connection
                 try (PgConnection pc = pgConnectionSupplier.get()) {
+
+                    try (PreparedStatement ps = pc.prepareStatement(PgConstants.LISTEN_SQL)) {
+                        ps.execute();
+                    }
+                    try (PreparedStatement ps = pc.prepareStatement(
+                            PgConstants.LISTEN_ROUNDTRIP_CHANNEL_SQL)) {
+                        ps.execute();
+                    }
+                    l.countDown();
+
                     boolean poll = true;
                     while (running.get()) {
-                        try (PreparedStatement ps = pc.prepareStatement(PgConstants.LISTEN_SQL)) {
-                            log.trace("Running LISTEN command");
-                            ps.execute();
-                        }
+
                         if (poll) {
                             // make sure, we did not miss anything while
                             // reconnecting,
                             postEvent("scheduled-poll");
                             poll = false;
                         }
-                        if (pgConnectionTester.test(pc)) {
-                            log.trace("Waiting for notifications for {}ms",
-                                    blockingWaitTimeInMillis);
-                            l.countDown();
-                            PGNotification[] notifications = pc.getNotifications(
-                                    blockingWaitTimeInMillis);
-                            if ((notifications != null) && (notifications.length > 0)) {
-                                final String name = notifications[0].getName();
-                                log.trace("notifying consumers for '{}'", name);
-                                postEvent(name);
-                            } else {
-                                log.trace("No notifications yet. Looping.");
-                            }
-                        } else {
-                            throw new SQLException("Connection is failing test");
+
+                        // listen to the real thing or pings
+                        PGNotification[] notifications = pc.getNotifications(
+                                blockingWaitTimeInMillis);
+                        if (notifications == null) {
+                            notifications = sendProbeAndWaitForEcho(pc);
                         }
+
+                        if (Arrays.stream(notifications)
+                                .anyMatch(n -> n.getName().equals(PgConstants.CHANNEL_NAME))) {
+                            log.trace("notifying consumers for '{}'", PgConstants.CHANNEL_NAME);
+                            postEvent(PgConstants.CHANNEL_NAME);
+                        } else {
+                            log.trace("No notifications yet. Looping.");
+                        }
+
                     }
                 } catch (SQLException e) {
                     log.warn("While waiting for Notifications", e);
@@ -118,9 +130,23 @@ public class PgListener implements InitializingBean, DisposableBean {
         }
     }
 
+    private PGNotification[] sendProbeAndWaitForEcho(PgConnection connection) throws SQLException {
+        connection.prepareCall(PgConstants.NOTIFY_ROUNDTRIP).execute();
+        PGNotification[] notifications = connection.getNotifications(
+                MAX_ALLOWED_NOTIFICATION_LATENCY_IN_MILLIS);
+        if (notifications == null) {
+            // missed the notifications from the DB, something is fishy
+            // here....
+            throw new SQLException("Missed roundtrip notification from channel '"
+                    + PgConstants.ROUNDTRIP_CHANNEL_NAME + "'");
+        } else {
+            return notifications;
+        }
+    }
+
     private void sleep() {
         try {
-            Thread.sleep(1000);
+            Thread.sleep(100);
         } catch (InterruptedException ignore) {
         }
 

--- a/factcast-store-pgsql/src/main/java/org/factcast/store/pgsql/internal/listen/PgListener.java
+++ b/factcast-store-pgsql/src/main/java/org/factcast/store/pgsql/internal/listen/PgListener.java
@@ -59,6 +59,7 @@ public class PgListener implements InitializingBean, DisposableBean {
     @NonNull
     final EventBus eventBus;
 
+    // TODO check if we can get rid of this now
     @NonNull
     final Predicate<Connection> pgConnectionTester;
 
@@ -126,6 +127,7 @@ public class PgListener implements InitializingBean, DisposableBean {
         }
     }
 
+    // TODO test separably
     private PGNotification[] sendProbeAndWaitForEcho(PgConnection connection) throws SQLException {
         connection.prepareCall(PgConstants.NOTIFY_ROUNDTRIP).execute();
         PGNotification[] notifications = connection.getNotifications(

--- a/factcast-store-pgsql/src/main/java/org/factcast/store/pgsql/internal/listen/PgListener.java
+++ b/factcast-store-pgsql/src/main/java/org/factcast/store/pgsql/internal/listen/PgListener.java
@@ -86,15 +86,11 @@ public class PgListener implements InitializingBean, DisposableBean {
                     }
                     l.countDown();
 
-                    boolean poll = true;
-                    while (running.get()) {
+                    // make sure, we did not miss anything while
+                    // reconnecting,
+                    postEvent("scheduled-poll");
 
-                        if (poll) {
-                            // make sure, we did not miss anything while
-                            // reconnecting,
-                            postEvent("scheduled-poll");
-                            poll = false;
-                        }
+                    while (running.get()) {
 
                         // listen to the real thing or pings
                         PGNotification[] notifications = pc.getNotifications(

--- a/factcast-store-pgsql/src/main/java/org/factcast/store/pgsql/internal/listen/PgListener.java
+++ b/factcast-store-pgsql/src/main/java/org/factcast/store/pgsql/internal/listen/PgListener.java
@@ -32,7 +32,7 @@ import org.springframework.beans.factory.InitializingBean;
 
 import com.google.common.eventbus.EventBus;
 
-import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -127,8 +127,8 @@ public class PgListener implements InitializingBean, DisposableBean {
         }
     }
 
-    // TODO test separably
-    private PGNotification[] sendProbeAndWaitForEcho(PgConnection connection) throws SQLException {
+    protected PGNotification[] sendProbeAndWaitForEcho(PgConnection connection)
+            throws SQLException {
         connection.prepareCall(PgConstants.NOTIFY_ROUNDTRIP).execute();
         PGNotification[] notifications = connection.getNotifications(
                 MAX_ALLOWED_NOTIFICATION_LATENCY_IN_MILLIS);
@@ -156,10 +156,11 @@ public class PgListener implements InitializingBean, DisposableBean {
         }
     }
 
-    @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+    @RequiredArgsConstructor
     public static class FactInsertionEvent {
 
         @SuppressWarnings("unused")
+        @Getter
         final String name;
     }
 

--- a/factcast-store-pgsql/src/test/java/org/factcast/store/pgsql/internal/listen/PgListenerTest.java
+++ b/factcast-store-pgsql/src/test/java/org/factcast/store/pgsql/internal/listen/PgListenerTest.java
@@ -217,8 +217,6 @@ public class PgListenerTest {
         assertEquals(3, totalNotifyCount);
     }
 
-    // TODO I'd like to test that the connection was closed. I currently don't
-    // see a simpler way
     @Test
     void testConnectionIsStopped() throws Exception {
         when(pgConnectionSupplier.get()).thenReturn(conn);

--- a/factcast-store-pgsql/src/test/java/org/factcast/store/pgsql/internal/listen/PgListenerTest.java
+++ b/factcast-store-pgsql/src/test/java/org/factcast/store/pgsql/internal/listen/PgListenerTest.java
@@ -19,10 +19,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
-import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.util.function.Predicate;
 
 import org.factcast.store.pgsql.internal.PgConstants;
 import org.factcast.store.pgsql.internal.listen.PgListener.FactInsertionEvent;
@@ -57,8 +55,6 @@ public class PgListenerTest {
     @Mock
     PreparedStatement ps;
 
-    Predicate<Connection> tester = c -> true;
-
     PGNotification[] someNotification = new PGNotification[] { //
             new Notification(PgConstants.CHANNEL_NAME, 1) };
 
@@ -72,7 +68,7 @@ public class PgListenerTest {
         when(conn.getNotifications(anyInt())).thenReturn(null);
         when(conn.prepareCall(anyString()).execute()).thenReturn(true);
 
-        PgListener l = new PgListener(ds, bus, tester);
+        PgListener l = new PgListener(ds, bus);
         l.afterPropertiesSet();
         sleep(100);
         l.destroy();
@@ -97,7 +93,7 @@ public class PgListenerTest {
                 new PGNotification[] { new Notification(PgConstants.CHANNEL_NAME, 3) }, null, null,
                 null);
 
-        PgListener l = new PgListener(ds, bus, tester);
+        PgListener l = new PgListener(ds, bus);
         l.afterPropertiesSet();
         sleep(500);
         l.destroy();
@@ -125,7 +121,7 @@ public class PgListenerTest {
         when(conn.prepareCall(anyString()).execute()).thenReturn(true);
         when(conn.getNotifications(anyInt())).thenReturn(null);
 
-        PgListener l = new PgListener(ds, bus, tester);
+        PgListener l = new PgListener(ds, bus);
         l.afterPropertiesSet();
         sleep(200);
         l.destroy();
@@ -147,7 +143,7 @@ public class PgListenerTest {
         when(conn.getNotifications(anyInt())).thenReturn(new PGNotification[] {
                 new Notification(unrelatedNotifyName, 1) }, null, null);
 
-        PgListener l = new PgListener(ds, bus, tester);
+        PgListener l = new PgListener(ds, bus);
         l.afterPropertiesSet();
         sleep(100);
         l.destroy();
@@ -164,7 +160,7 @@ public class PgListenerTest {
         when(ds.get()).thenReturn(conn);
         when(conn.prepareStatement(anyString())).thenReturn(mock(PreparedStatement.class));
 
-        PgListener l = new PgListener(ds, bus, tester);
+        PgListener l = new PgListener(ds, bus);
         l.afterPropertiesSet();
         l.destroy();
         sleep(150);// TODO flaky
@@ -173,7 +169,7 @@ public class PgListenerTest {
 
     @Test
     void testStopWithoutStarting() {
-        PgListener l = new PgListener(ds, bus, tester);
+        PgListener l = new PgListener(ds, bus);
         l.destroy();
         verifyNoMoreInteractions(conn);
     }
@@ -182,7 +178,7 @@ public class PgListenerTest {
     public void successfulProbesAreForwarded() throws SQLException {
         when(conn.getNotifications(anyInt())).thenReturn(someNotification);
 
-        PgListener l = new PgListener(ds, bus, tester);
+        PgListener l = new PgListener(ds, bus);
         val result = l.sendProbeAndWaitForEcho(conn);
         assertEquals(1, result.length);
         assertEquals(PgConstants.CHANNEL_NAME, result[0].getName());
@@ -192,7 +188,7 @@ public class PgListenerTest {
     public void sqlExceptionAfterUnsuccessfulProbe() throws SQLException {
         when(conn.getNotifications(anyInt())).thenReturn(null);
         Assertions.assertThrows(SQLException.class, () -> {
-            PgListener l = new PgListener(ds, bus, tester);
+            PgListener l = new PgListener(ds, bus);
             l.sendProbeAndWaitForEcho(conn);
         });
     }

--- a/factcast-store-pgsql/src/test/java/org/factcast/store/pgsql/internal/listen/PgListenerTest.java
+++ b/factcast-store-pgsql/src/test/java/org/factcast/store/pgsql/internal/listen/PgListenerTest.java
@@ -175,21 +175,21 @@ public class PgListenerTest {
     }
 
     @Test
-    public void successfulProbesAreForwarded() throws SQLException {
+    public void successfulHealthCheckForwardsNotifications() throws SQLException {
         when(conn.getNotifications(anyInt())).thenReturn(someNotification);
 
         PgListener l = new PgListener(ds, bus);
-        val result = l.sendProbeAndWaitForEcho(conn);
+        val result = l.checkDatabaseConnectionHealthy(conn);
         assertEquals(1, result.length);
         assertEquals(PgConstants.CHANNEL_NAME, result[0].getName());
     }
 
     @Test
-    public void sqlExceptionAfterUnsuccessfulProbe() throws SQLException {
+    public void sqlExceptionAfterUnsuccessfulHealthCheck() throws SQLException {
         when(conn.getNotifications(anyInt())).thenReturn(null);
         Assertions.assertThrows(SQLException.class, () -> {
             PgListener l = new PgListener(ds, bus);
-            l.sendProbeAndWaitForEcho(conn);
+            l.checkDatabaseConnectionHealthy(conn);
         });
     }
 

--- a/factcast-store-pgsql/src/test/java/org/factcast/store/pgsql/internal/listen/PgListenerTest.java
+++ b/factcast-store-pgsql/src/test/java/org/factcast/store/pgsql/internal/listen/PgListenerTest.java
@@ -27,6 +27,7 @@ import org.factcast.store.pgsql.internal.PgConstants;
 import org.factcast.store.pgsql.internal.listen.PgListener.FactInsertionEvent;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.*;
+import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -46,7 +47,7 @@ public class PgListenerTest {
     @Mock
     AsyncEventBus bus;
 
-    @Mock
+    @Mock(answer = Answers.RETURNS_MOCKS)
     PgConnection conn;
 
     @Mock
@@ -115,6 +116,9 @@ public class PgListenerTest {
 
         when(ds.get()).thenReturn(conn);
         when(conn.prepareStatement(anyString())).thenReturn(ps);
+
+        // when(conn.prepareCall(anyString()).execute());
+        // when(conn.prepareCall(anyString()).execute()).thenReturn(true);
 
         PgListener l = new PgListener(ds, bus, tester);
         when(conn.getNotifications(anyInt())).thenReturn(null);


### PR DESCRIPTION
With FC, we should have a test roundtrip that makes sure that postgres listeners are not stale or must be reconnected. This will be done to make sure the database is not the reason for stale/slow consumers. 

AC: FactCast tests his database listeners continously an detects possible stale connections

AC: Detected staleness is mitigated immediately

AC: All active consumers are triggered for a re-query if stale listeners were detected