### PR TITLE
#959: fix response compression, add some tracing

### DIFF
--- a/factcast-client-grpc/src/main/java/org/factcast/client/grpc/codec/Lz4GrpcClientCodec.java
+++ b/factcast-client-grpc/src/main/java/org/factcast/client/grpc/codec/Lz4GrpcClientCodec.java
@@ -15,14 +15,20 @@
  */
 package org.factcast.client.grpc.codec;
 
-import java.io.*;
+import java.io.InputStream;
+import java.io.OutputStream;
 
-import io.grpc.*;
-import net.devh.boot.grpc.common.codec.*;
+import io.grpc.Codec;
+import net.devh.boot.grpc.common.codec.CodecType;
+import net.devh.boot.grpc.common.codec.GrpcCodec;
 import net.jpountz.lz4.*;
 
 @GrpcCodec(advertised = true, codecType = CodecType.ALL)
 public class Lz4GrpcClientCodec implements Codec {
+    private static final LZ4FastDecompressor decomp = LZ4Factory.fastestInstance()
+            .fastDecompressor();
+
+    private static final LZ4Compressor comp = LZ4Factory.fastestInstance().fastCompressor();
 
     @Override
     public String getMessageEncoding() {
@@ -31,11 +37,11 @@ public class Lz4GrpcClientCodec implements Codec {
 
     @Override
     public InputStream decompress(InputStream inputStream) {
-        return new LZ4BlockInputStream(inputStream);
+        return new LZ4BlockInputStream(inputStream, decomp);
     }
 
     @Override
     public OutputStream compress(OutputStream outputStream) {
-        return new LZ4BlockOutputStream(outputStream);
+        return new LZ4BlockOutputStream(outputStream, 65536, comp);
     }
 }

--- a/factcast-client-grpc/src/test/java/org/factcast/client/grpc/GrpcFactStoreTest.java
+++ b/factcast-client-grpc/src/test/java/org/factcast/client/grpc/GrpcFactStoreTest.java
@@ -72,10 +72,10 @@ class GrpcFactStoreTest {
     @InjectMocks
     private GrpcFactStore uut;
 
-    @Mock
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private RemoteFactStoreBlockingStub blockingStub;
 
-    @Mock
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private RemoteFactStoreStub stub;
 
     @Mock

--- a/factcast-grpc-api/src/main/java/org/factcast/grpc/api/Headers.java
+++ b/factcast-grpc-api/src/main/java/org/factcast/grpc/api/Headers.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2017-2020 factcast.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.factcast.grpc.api;
+
+import io.grpc.Metadata;
+
+public class Headers {
+    private static final String GRPC_COMPRESSION_HEADER = "fc-msgcomp";
+
+    public static final Metadata.Key<String> MESSAGE_COMPRESSION = Metadata.Key.of(
+            Headers.GRPC_COMPRESSION_HEADER,
+            Metadata.ASCII_STRING_MARSHALLER);
+
+}

--- a/factcast-server-grpc/src/main/java/org/factcast/server/grpc/BlockingStreamObserver.java
+++ b/factcast-server-grpc/src/main/java/org/factcast/server/grpc/BlockingStreamObserver.java
@@ -40,11 +40,11 @@ public class BlockingStreamObserver<T> implements StreamObserver<T> {
 
     private static final int WAIT_TIME = 1000;
 
-    final ServerCallStreamObserver<T> delegate;
+    private final ServerCallStreamObserver<T> delegate;
 
-    final Object lock = new Object();
+    private final Object lock = new Object();
 
-    final String id;
+    private final String id;
 
     BlockingStreamObserver(@NonNull String id, @NonNull ServerCallStreamObserver<T> delegate) {
         this.id = id;
@@ -67,7 +67,7 @@ public class BlockingStreamObserver<T> implements StreamObserver<T> {
             synchronized (lock) {
                 if (!delegate.isReady()) {
                     for (int i = 1; i <= RETRY_COUNT; i++) {
-                        log.debug("{} channel not ready. Slow client? Attempt: {}/{}", id, i,
+                        log.trace("{} channel not ready. Slow client? Attempt: {}/{}", id, i,
                                 RETRY_COUNT);
                         try {
                             lock.wait(WAIT_TIME);

--- a/factcast-server-grpc/src/main/java/org/factcast/server/grpc/FactStoreGrpcService.java
+++ b/factcast-server-grpc/src/main/java/org/factcast/server/grpc/FactStoreGrpcService.java
@@ -251,6 +251,7 @@ public class FactStoreGrpcService extends RemoteFactStoreImplBase {
         if (responseObserver instanceof ServerCallStreamObserver) {
             ServerCallStreamObserver obs = (ServerCallStreamObserver) responseObserver;
             obs.setMessageCompression(true);
+            log.trace("enabled response compression");
         }
     }
 
@@ -265,7 +266,7 @@ public class FactStoreGrpcService extends RemoteFactStoreImplBase {
         HashMap<String, String> properties = new HashMap<>();
         retrieveImplementationVersion(properties);
         properties.put(Capabilities.CODECS.toString(), codecs.available());
-        log.info("Handshake properties: {} ", properties);
+        log.info("handshake properties: {} ", properties);
         return properties;
     }
 

--- a/factcast-server-grpc/src/main/java/org/factcast/server/grpc/GrpcCompressionInterceptor.java
+++ b/factcast-server-grpc/src/main/java/org/factcast/server/grpc/GrpcCompressionInterceptor.java
@@ -16,6 +16,7 @@
 package org.factcast.server.grpc;
 
 import org.factcast.grpc.api.CompressionCodecs;
+import org.factcast.grpc.api.Headers;
 
 import io.grpc.Metadata;
 import io.grpc.ServerCall;
@@ -23,21 +24,21 @@ import io.grpc.ServerCall.Listener;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor;
 
 @GrpcGlobalServerInterceptor
 @RequiredArgsConstructor
+@Slf4j
 public class GrpcCompressionInterceptor implements ServerInterceptor {
-
-    public final Metadata.Key<String> GRPC_ACCEPT_ENCODING = Metadata.Key.of("grpc-accept-encoding",
-            Metadata.ASCII_STRING_MARSHALLER);
 
     private final CompressionCodecs codecs;
 
     @Override
     public <ReqT, RespT> Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call,
             Metadata headers, ServerCallHandler<ReqT, RespT> next) {
-        codecs.selectFrom(headers.get(GRPC_ACCEPT_ENCODING)).ifPresent(c -> {
+        codecs.selectFrom(headers.get(Headers.MESSAGE_COMPRESSION)).ifPresent(c -> {
+            log.trace("setting response compression default to {}", c);
             call.setCompression(c);
             // server code still needs to set call response to compressible.
             // defaults to not use any compression.

--- a/factcast-server-grpc/src/main/java/org/factcast/server/grpc/codec/Lz4GrpcServerCodec.java
+++ b/factcast-server-grpc/src/main/java/org/factcast/server/grpc/codec/Lz4GrpcServerCodec.java
@@ -21,11 +21,14 @@ import java.io.OutputStream;
 import io.grpc.Codec;
 import net.devh.boot.grpc.common.codec.CodecType;
 import net.devh.boot.grpc.common.codec.GrpcCodec;
-import net.jpountz.lz4.LZ4BlockInputStream;
-import net.jpountz.lz4.LZ4BlockOutputStream;
+import net.jpountz.lz4.*;
 
 @GrpcCodec(advertised = true, codecType = CodecType.ALL)
 public class Lz4GrpcServerCodec implements Codec {
+    private static final LZ4FastDecompressor decomp = LZ4Factory.fastestInstance()
+            .fastDecompressor();
+
+    private static final LZ4Compressor comp = LZ4Factory.fastestInstance().fastCompressor();
 
     @Override
     public String getMessageEncoding() {
@@ -34,11 +37,11 @@ public class Lz4GrpcServerCodec implements Codec {
 
     @Override
     public InputStream decompress(InputStream inputStream) {
-        return new LZ4BlockInputStream(inputStream);
+        return new LZ4BlockInputStream(inputStream, decomp);
     }
 
     @Override
     public OutputStream compress(OutputStream outputStream) {
-        return new LZ4BlockOutputStream(outputStream);
+        return new LZ4BlockOutputStream(outputStream, 65536, comp);
     }
 }

--- a/factcast-server-grpc/src/test/java/org/factcast/server/grpc/GrpcCompressionInterceptorTest.java
+++ b/factcast-server-grpc/src/test/java/org/factcast/server/grpc/GrpcCompressionInterceptorTest.java
@@ -18,6 +18,7 @@ package org.factcast.server.grpc;
 import static org.mockito.Mockito.*;
 
 import org.factcast.grpc.api.CompressionCodecs;
+import org.factcast.grpc.api.Headers;
 import org.junit.jupiter.api.*;
 
 import io.grpc.Metadata;
@@ -45,7 +46,7 @@ class GrpcCompressionInterceptorTest {
     void interceptCallGZip() {
         ServerCall call = mock(ServerCall.class);
         Metadata metadata = mock(Metadata.class);
-        when(metadata.get(uut.GRPC_ACCEPT_ENCODING)).thenReturn("gzip");
+        when(metadata.get(Headers.MESSAGE_COMPRESSION)).thenReturn("gzip");
         ServerCallHandler next = mock(ServerCallHandler.class);
 
         uut.interceptCall(call, metadata, next);


### PR DESCRIPTION
call compression was working on request, but not response due to missing call headers.