### PR TITLE
Fix transformation handling when adding a new array

### DIFF
--- a/factcast-store-pgsql/src/main/java/org/factcast/store/pgsql/registry/transformation/chains/NashornTransformer.java
+++ b/factcast-store-pgsql/src/main/java/org/factcast/store/pgsql/registry/transformation/chains/NashornTransformer.java
@@ -16,20 +16,15 @@
 package org.factcast.store.pgsql.registry.transformation.chains;
 
 import com.fasterxml.jackson.databind.JsonNode;
-
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-
 import javax.script.Compilable;
 import javax.script.Invocable;
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
 import javax.script.ScriptException;
-
 import jdk.nashorn.api.scripting.NashornScriptEngineFactory;
 import jdk.nashorn.api.scripting.ScriptObjectMirror;
-
 import org.apache.commons.collections4.map.LRUMap;
 import org.factcast.core.subscription.TransformationException;
 import org.factcast.core.util.FactCastJson;
@@ -92,8 +87,8 @@ public class NashornTransformer implements Transformer {
   }
 
   private Object transformMapValue(Object input) {
-    if (input instanceof ScriptObjectMirror && ((ScriptObjectMirror)input).isArray()) {
-      return ((ScriptObjectMirror)input).to(List.class);
+    if (input instanceof ScriptObjectMirror && ((ScriptObjectMirror) input).isArray()) {
+      return ((ScriptObjectMirror) input).to(List.class);
     } else if (input instanceof Map) {
       fixArrayTransformations((Map<String, Object>) input);
       return input;

--- a/factcast-store-pgsql/src/main/java/org/factcast/store/pgsql/registry/transformation/chains/NashornTransformer.java
+++ b/factcast-store-pgsql/src/main/java/org/factcast/store/pgsql/registry/transformation/chains/NashornTransformer.java
@@ -16,13 +16,20 @@
 package org.factcast.store.pgsql.registry.transformation.chains;
 
 import com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+
 import javax.script.Compilable;
 import javax.script.Invocable;
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
 import javax.script.ScriptException;
+
 import jdk.nashorn.api.scripting.NashornScriptEngineFactory;
+import jdk.nashorn.api.scripting.ScriptObjectMirror;
+
 import org.apache.commons.collections4.map.LRUMap;
 import org.factcast.core.subscription.TransformationException;
 import org.factcast.core.util.FactCastJson;
@@ -68,10 +75,30 @@ public class NashornTransformer implements Transformer {
         @SuppressWarnings("unchecked")
         Map<String, Object> jsonAsMap = FactCastJson.convertValue(input, Map.class);
         invocable.invokeFunction("transform", jsonAsMap);
+        fixArrayTransformations(jsonAsMap);
         return FactCastJson.toJsonNode(jsonAsMap);
       } catch (NoSuchMethodException | ScriptException e) {
         throw new TransformationException(e);
       }
+    }
+  }
+
+  void fixArrayTransformations(Map<String, Object> input) {
+    // in order to keep memory footprint low and keep map order, replace in-place on demand
+    for (String key : input.keySet()) {
+      Object value = transformMapValue(input.get(key));
+      input.put(key, value);
+    }
+  }
+
+  private Object transformMapValue(Object input) {
+    if (input instanceof ScriptObjectMirror && ((ScriptObjectMirror)input).isArray()) {
+      return ((ScriptObjectMirror)input).to(List.class);
+    } else if (input instanceof Map) {
+      fixArrayTransformations((Map<String, Object>) input);
+      return input;
+    } else {
+      return input;
     }
   }
 }

--- a/factcast-store-pgsql/src/test/java/org/factcast/store/pgsql/registry/transformation/chains/NashornTransformerTest.java
+++ b/factcast-store-pgsql/src/test/java/org/factcast/store/pgsql/registry/transformation/chains/NashornTransformerTest.java
@@ -1,0 +1,56 @@
+package org.factcast.store.pgsql.registry.transformation.chains;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import jdk.nashorn.api.scripting.ScriptObjectMirror;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class NashornTransformerTest {
+
+    private NashornTransformer uut = new NashornTransformer();
+
+    @Test
+    void fixArrayTransformations_NoFixNeeded() {
+        final Map<String, Object> in = new HashMap<>();
+        in.put("anInt", 42);
+        in.put("aString", "test");
+        in.put("aList", Collections.singleton(21));
+        final Map<String, Object> nestedMap = new HashMap<>();
+        nestedMap.put("a", "b");
+        in.put("anObject", nestedMap);
+
+        uut.fixArrayTransformations(in);
+
+        assertThat(in)
+            .containsEntry("anInt", 42)
+            .containsEntry("aString", "test")
+            .containsEntry("aList", Collections.singleton(21));
+        assertThat((Map<String, Object>)in.get("anObject")).containsEntry("a", "b");
+    }
+
+    @Test
+    void fixArrayTransformations_ArrayFixed() {
+        final Map<String, Object> in = new HashMap<>();
+        in.put("anInt", 42);
+        ScriptObjectMirror array = mock(ScriptObjectMirror.class);
+        when(array.isArray()).thenReturn(true);
+        when(array.to(List.class)).thenReturn(Collections.singletonList(1));
+        in.put("newArray", array);
+
+
+        uut.fixArrayTransformations(in);
+
+        assertThat(in)
+            .containsEntry("anInt", 42)
+            .containsEntry("newArray", Collections.singletonList(1));
+    }
+}

--- a/factcast-store-pgsql/src/test/java/org/factcast/store/pgsql/registry/transformation/chains/NashornTransformerTest.java
+++ b/factcast-store-pgsql/src/test/java/org/factcast/store/pgsql/registry/transformation/chains/NashornTransformerTest.java
@@ -1,56 +1,53 @@
 package org.factcast.store.pgsql.registry.transformation.chains;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import org.junit.jupiter.api.Test;
-
-import jdk.nashorn.api.scripting.ScriptObjectMirror;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import jdk.nashorn.api.scripting.ScriptObjectMirror;
+import org.junit.jupiter.api.Test;
+
 class NashornTransformerTest {
 
-    private NashornTransformer uut = new NashornTransformer();
+  private NashornTransformer uut = new NashornTransformer();
 
-    @Test
-    void fixArrayTransformations_NoFixNeeded() {
-        final Map<String, Object> in = new HashMap<>();
-        in.put("anInt", 42);
-        in.put("aString", "test");
-        in.put("aList", Collections.singleton(21));
-        final Map<String, Object> nestedMap = new HashMap<>();
-        nestedMap.put("a", "b");
-        in.put("anObject", nestedMap);
+  @Test
+  void fixArrayTransformations_NoFixNeeded() {
+    final Map<String, Object> in = new HashMap<>();
+    in.put("anInt", 42);
+    in.put("aString", "test");
+    in.put("aList", Collections.singleton(21));
+    final Map<String, Object> nestedMap = new HashMap<>();
+    nestedMap.put("a", "b");
+    in.put("anObject", nestedMap);
 
-        uut.fixArrayTransformations(in);
+    uut.fixArrayTransformations(in);
 
-        assertThat(in)
-            .containsEntry("anInt", 42)
-            .containsEntry("aString", "test")
-            .containsEntry("aList", Collections.singleton(21));
-        assertThat((Map<String, Object>)in.get("anObject")).containsEntry("a", "b");
-    }
+    assertThat(in)
+        .containsEntry("anInt", 42)
+        .containsEntry("aString", "test")
+        .containsEntry("aList", Collections.singleton(21));
+    assertThat((Map<String, Object>) in.get("anObject")).containsEntry("a", "b");
+  }
 
-    @Test
-    void fixArrayTransformations_ArrayFixed() {
-        final Map<String, Object> in = new HashMap<>();
-        in.put("anInt", 42);
-        ScriptObjectMirror array = mock(ScriptObjectMirror.class);
-        when(array.isArray()).thenReturn(true);
-        when(array.to(List.class)).thenReturn(Collections.singletonList(1));
-        in.put("newArray", array);
+  @Test
+  void fixArrayTransformations_ArrayFixed() {
+    final Map<String, Object> in = new HashMap<>();
+    in.put("anInt", 42);
+    ScriptObjectMirror array = mock(ScriptObjectMirror.class);
+    when(array.isArray()).thenReturn(true);
+    when(array.to(List.class)).thenReturn(Collections.singletonList(1));
+    in.put("newArray", array);
 
+    uut.fixArrayTransformations(in);
 
-        uut.fixArrayTransformations(in);
-
-        assertThat(in)
-            .containsEntry("anInt", 42)
-            .containsEntry("newArray", Collections.singletonList(1));
-    }
+    assertThat(in)
+        .containsEntry("anInt", 42)
+        .containsEntry("newArray", Collections.singletonList(1));
+  }
 }

--- a/factcast-store-pgsql/src/test/java/org/factcast/store/pgsql/registry/transformation/chains/TransformationChainsTest.java
+++ b/factcast-store-pgsql/src/test/java/org/factcast/store/pgsql/registry/transformation/chains/TransformationChainsTest.java
@@ -44,6 +44,27 @@ public class TransformationChainsTest {
   final TransformationKey key = TransformationKey.of("ns", "UserCreated");
 
   @Test
+  void testAddingNewArray() throws Exception {
+    ArrayList<Transformation> all = Lists.newArrayList();
+    all.add(SingleTransformation.of(key, 1, 2, "function transform(ev) {ev.arr = [1,2,3,'4']}"));
+    all.add(SingleTransformation.of(key, 2, 3, "function transform(ev) {ev.newField=true}"));
+
+    when(r.get(key)).thenReturn(all);
+
+    TransformationChain chain = uut.get(key, 1, 3);
+
+    assertEquals(1, chain.fromVersion());
+    assertEquals(3, chain.toVersion());
+    assertEquals(key, chain.key());
+    assertEquals("[1, 2, 3]", chain.id());
+    assertThat(chain.transformationCode()).isPresent();
+
+    JsonNode input = FactCastJson.readTree("{}");
+    JsonNode actual = new NashornTransformer().transform(chain, input);
+    assertThat(actual.toString()).isEqualTo("{\"arr\":[1,2,3,\"4\"],\"newField\":true}");
+  }
+
+  @Test
   void testStraightLine() throws Exception {
 
     ArrayList<Transformation> all = Lists.newArrayList();


### PR DESCRIPTION
created by olewehrmeyer:

__________

Currently Factcast includes a bug, where event transformations that add a new array are handled incorrectly.

When using a transformation function like this:
```js
function transform(event) {
  event.newField = [1 ,2 ,3];
}
```
the new field would be transformed to
```json
{
  "newField" : {
    "0": 1,
    "1": 2,
    "2": 3
  }
}
```

This happens as Jackson mishandles the Nashorn internal ScriptObjectMirror, which is an array if ScriptObjectMirror#isArray == true and an object otherwise. As it however implements Map internally, Jackson treats it as a Map.

Implementation note: I decided against telling Jackson how to treat this ScriptObjectMirror as I for one did not want to touch the FactCastJson class due to the "do not change mapper" comment and it kind of felt wrong to configure Jackson how to deal with this Nashorn weirdness, so I opted to simply filter this before passing it to Jackson.