### PR TITLE
#1506: synchronized access to engines

### DIFF
--- a/factcast-store/src/main/java/org/factcast/store/registry/transformation/chains/GraalJsTransformer.java
+++ b/factcast-store/src/main/java/org/factcast/store/registry/transformation/chains/GraalJsTransformer.java
@@ -15,27 +15,35 @@
  */
 package org.factcast.store.registry.transformation.chains;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.oracle.truffle.js.scriptengine.GraalJSScriptEngine;
+import static java.util.Collections.synchronizedMap;
+
 import java.util.List;
 import java.util.Map;
+
 import javax.script.Compilable;
 import javax.script.Invocable;
 import javax.script.ScriptEngine;
 import javax.script.ScriptException;
-import lombok.val;
+
 import org.apache.commons.collections4.map.LRUMap;
 import org.factcast.core.subscription.TransformationException;
 import org.factcast.core.util.FactCastJson;
 import org.factcast.store.registry.transformation.Transformation;
 import org.graalvm.polyglot.Value;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.oracle.truffle.js.scriptengine.GraalJSScriptEngine;
+
+import lombok.NonNull;
+import lombok.val;
+
 public class GraalJsTransformer implements Transformer {
 
   private static final int ENGINE_CACHE_CAPACITY = 128;
 
-  private static final Object MUTEX = new Object();
-  private static final LRUMap<String, Invocable> warmEngines = new LRUMap<>(ENGINE_CACHE_CAPACITY);
+  private static final Object ENGINE_MUTEX = new Object();
+  private static final Map<String, Invocable> warmEngines =
+      synchronizedMap(new LRUMap<>(ENGINE_CACHE_CAPACITY));
 
   static {
     // important property to enable nashorn compat mode within GraalJs
@@ -52,39 +60,62 @@ public class GraalJsTransformer implements Transformer {
 
     if (!t.transformationCode().isPresent()) {
       return input;
+
     } else {
       String js = t.transformationCode().get();
 
       Invocable invocable = warmEngines.get(js);
+
       if (invocable == null) {
-        ScriptEngine engine = null;
-
-        synchronized (MUTEX) {
-          // no guarantee is found anywhere, that creating a
-          // scriptEngine was
-          // supposed to be threadsafe, so...
-          engine = GraalJSScriptEngine.create(null, null);
-        }
-
-        try {
-          Compilable compilable = (Compilable) engine;
-          compilable.compile(js).eval();
-          invocable = (Invocable) engine;
-          warmEngines.put(js, invocable);
-        } catch (ScriptException e) {
-          throw new TransformationException(e);
-        }
+        invocable = warmEngine(js);
+        // in case there was no warm engine yet, there is a small chance we create several ones
+        // and use them in parallel, but that is fine. We'll keep the last one in that case.
+        warmEngines.put(js, invocable);
       }
 
-      try {
-        @SuppressWarnings("unchecked")
-        Map<String, Object> jsonAsMap = FactCastJson.convertValue(input, Map.class);
+      return runJSTransformation(input, invocable);
+    }
+  }
+
+  private JsonNode runJSTransformation(JsonNode input, Invocable invocable) {
+    try {
+      @SuppressWarnings("unchecked")
+      Map<String, Object> jsonAsMap = FactCastJson.convertValue(input, Map.class);
+
+      synchronized (invocable) {
         invocable.invokeFunction("transform", jsonAsMap);
-        fixArrayTransformations(jsonAsMap);
-        return FactCastJson.toJsonNode(jsonAsMap);
-      } catch (NoSuchMethodException | ScriptException e) {
-        throw new TransformationException(e);
       }
+
+      fixArrayTransformations(jsonAsMap);
+
+      return FactCastJson.toJsonNode(jsonAsMap);
+
+    } catch (NoSuchMethodException | ScriptException e) {
+      throw new TransformationException(e);
+    }
+  }
+
+  @NonNull
+  private Invocable warmEngine(String js) {
+    ScriptEngine engine;
+
+    synchronized (ENGINE_MUTEX) {
+      // no guarantee is found anywhere, that creating a
+      // scriptEngine was supposed to be threadsafe, so...
+      engine = GraalJSScriptEngine.create(null, null);
+    }
+
+    try {
+      Compilable compilable = (Compilable) engine;
+
+      synchronized (engine) {
+        compilable.compile(js).eval();
+      }
+
+      return (Invocable) engine;
+
+    } catch (ScriptException e) {
+      throw new TransformationException(e);
     }
   }
 

--- a/factcast-store/src/test/java/org/factcast/store/registry/transformation/chains/GraalJsTransformerTest.java
+++ b/factcast-store/src/test/java/org/factcast/store/registry/transformation/chains/GraalJsTransformerTest.java
@@ -1,18 +1,26 @@
 package org.factcast.store.registry.transformation.chains;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.HashMap;
 import java.util.Optional;
-import lombok.val;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor;
+
 import org.factcast.store.registry.transformation.Transformation;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.SneakyThrows;
+import lombok.val;
 
 @ExtendWith(MockitoExtension.class)
 class GraalJsTransformerTest {
@@ -48,5 +56,52 @@ class GraalJsTransformerTest {
     assertThat(result.get("hobbies").get(0).asText()).isEqualTo("foo");
     assertThat(result.get("childMap").get("anotherHobbies").isArray()).isTrue();
     assertThat(result.get("childMap").get("anotherHobbies").get(0).asText()).isEqualTo("bar");
+  }
+
+  @Test
+  @SneakyThrows
+  void testParallelAccess() {
+    when(transformation.transformationCode())
+        .thenReturn(
+            Optional.of(
+                "function transform(e) { \n"
+                    + "  console.log('Starting Busy Wait...'); \n"
+                    // code to do busy waiting in JS:
+                    + "  const date = Date.now();\n"
+                    + "  const milliseconds = 2000;\n"
+                    + "  let currentDate = null;\n"
+                    + "  do {\n"
+                    + "    currentDate = Date.now();\n"
+                    + "  } while (currentDate - date < milliseconds);\n"
+                    + "  console.log('Done busy waiting.'); \n"
+                    // actual transformation
+                    + "  e.x = e.y; }\n"));
+
+    val d1 = new HashMap<String, Object>();
+    d1.put("y", "1");
+
+    val d2 = new HashMap<String, Object>();
+    d2.put("y", "2");
+
+    // warm up engine
+    uut.transform(transformation, om.convertValue(d1, JsonNode.class));
+
+    Callable<JsonNode> c1 =
+        () -> uut.transform(transformation, om.convertValue(d1, JsonNode.class));
+    Callable<JsonNode> c2 =
+        () -> uut.transform(transformation, om.convertValue(d2, JsonNode.class));
+
+    ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(2);
+    try {
+      Future<JsonNode> result1 = executor.submit(c1);
+      Future<JsonNode> result2 = executor.submit(c2);
+      JsonNode n1 = result1.get();
+      JsonNode n2 = result2.get();
+
+      assertThat(n1.get("x").asText()).isEqualTo("1");
+      assertThat(n2.get("x").asText()).isEqualTo("2");
+    } finally {
+      executor.shutdown();
+    }
   }
 }


### PR DESCRIPTION
GraalJS [does not allow concurrent access to engines any more](https://medium.com/graalvm/multi-threaded-java-javascript-language-interoperability-in-graalvm-2f19c1f9c37b).

We will now wait in case two threads share the same engine.

In the rare case n threads try to warm up the engine with the same JS at the same time, they will work with n engines in parallel, but for later we will only keep one of those engines.