### PR TITLE
[schema-reg-cli] Catch exceptions during transformation

### DIFF
--- a/factcast-schema-registry-cli/src/main/kotlin/org/factcast/schema/registry/cli/validation/ProjectError.kt
+++ b/factcast-schema-registry-cli/src/main/kotlin/org/factcast/schema/registry/cli/validation/ProjectError.kt
@@ -41,6 +41,7 @@ sealed class ProjectError {
     class WrongVersionFormat(val version: String, val path: Path) : ProjectError()
     class NoUpcastForVersion(val fromVersion: Int, val toVersion: Int, val type: String) : ProjectError()
     class TransformationValidationError(val type: String, val fromVersion: Int, val toVersion: Int, val result: ProcessingReport) : ProjectError()
+    class TransformationError(val type: String, val fromVersion: Int, val toVersion: Int, val exception: Throwable) : ProjectError()
     class NoDowncastForVersion(val fromVersion: Int, val toVersion: Int, val type: String, val result: ProcessingReport) : ProjectError()
     class MissingVersionForTransformation(val fromVersion: Int, val toVersion: Int, val transformationPath: Path) : ProjectError()
 }

--- a/factcast-schema-registry-cli/src/main/kotlin/org/factcast/schema/registry/cli/validation/formatErrors.kt
+++ b/factcast-schema-registry-cli/src/main/kotlin/org/factcast/schema/registry/cli/validation/formatErrors.kt
@@ -53,5 +53,8 @@ ${it.result.joinToString("\n") { result ->
             """.trimIndent()
         is ProjectError.MissingVersionForTransformation ->
             "Version ${it.fromVersion} or ${it.toVersion} does not exist for ${it.transformationPath}"
+        is ProjectError.TransformationError -> """Exception during transformation of ${it.type} from ${it.fromVersion} to ${it.toVersion}:
+${it.exception.message}
+        """.trimIndent()
     }
 }

--- a/factcast-schema-registry-cli/src/main/kotlin/org/factcast/schema/registry/cli/validation/validators/impl/TransformationValidationServiceImpl.kt
+++ b/factcast-schema-registry-cli/src/main/kotlin/org/factcast/schema/registry/cli/validation/validators/impl/TransformationValidationServiceImpl.kt
@@ -15,8 +15,9 @@
  */
 package org.factcast.schema.registry.cli.validation.validators.impl
 
+import com.fasterxml.jackson.databind.JsonNode
 import com.google.common.annotations.VisibleForTesting
-import org.factcast.schema.registry.cli.domain.Project
+import org.factcast.schema.registry.cli.domain.*
 import org.factcast.schema.registry.cli.fs.FileSystemService
 import org.factcast.schema.registry.cli.utils.SchemaService
 import org.factcast.schema.registry.cli.utils.mapEventTransformations
@@ -65,15 +66,21 @@ class TransformationValidationServiceImpl(
 
         schemaService
             .loadSchema(toVersion.schemaPath)
-            .fold({ listOf(it) }, { schema ->
-                examples.mapNotNull {
-                    val transformationResult =
-                        transformationEvaluator.evaluate(ns, event, transformation, it)
+            .fold({ listOf(it) }) { schema ->
+                examples.mapNotNull { example ->
+                    val transformationResult: JsonNode
+                    try {
+                        transformationResult = transformationEvaluator.evaluate(ns, event, transformation, example)
+                    } catch (e: Exception) {
+                        return@mapNotNull ProjectError.TransformationError(
+                            event.type,
+                            fromVersion.version,
+                            toVersion.version,
+                            e
+                        )
+                    }
 
-                    val validationResult = schema.validate(
-                        transformationResult
-                    )
-
+                    val validationResult = schema.validate(transformationResult)
                     if (validationResult.isSuccess) {
                         null
                     } else {
@@ -85,7 +92,7 @@ class TransformationValidationServiceImpl(
                         )
                     }
                 }
-            })
+            }
     }.flatten()
 
     @VisibleForTesting


### PR DESCRIPTION
This MR fixes #1758.

Output will look like this after merge:

```
[INFO] --- factcast-schema-registry-maven-plugin:0.4.3:build (build) @ schema-registry-registry ---
[INFO] Established active environments: [cli]
[INFO] Starting building Factcast Schema Registry
[INFO] Input: src/main/registry
[INFO] 
[ERROR] Exception during transformation of MyEvent from 1 to 2:
javax.script.ScriptException: org.graalvm.polyglot.PolyglotException: TypeError: undefined has no such function "split"
```