### PR TITLE
revert gin index optimization

### DIFF
--- a/factcast-store/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/factcast-store/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -135,16 +135,20 @@ databaseChangeLog:
             splitStatements: false
             stripComments: true
 
-  - changeSet:
-      id: gin_fast_update
-      runInTransaction: false
-      author: uweschaefer
-      changes:
-        - sqlFile:
-            encoding: utf8
-            path: factcast/issue1696/gin_fast_update.sql
-            relativeToChangelogFile: true
-            splitStatements: false
-            stripComments: true
+# this has to be reverted: in high load situations, the alter index might not be able to acquire the necessary locks
+# so that the server startup hangs, or fails.
+# we'll have to move it to the documentation
+#
+#  - changeSet:
+#      id: gin_fast_update
+#      runInTransaction: false
+#      author: uweschaefer
+#      changes:
+#        - sqlFile:
+#            encoding: utf8
+#            path: factcast/issue1696/gin_fast_update.sql
+#            relativeToChangelogFile: true
+#            splitStatements: false
+#            stripComments: true
 
 


### PR DESCRIPTION
Testing showed that in high load situations, the alter index might not be able to acquire the necessary locks
so that the server startup hangs, or fails.

we'll have to move it to the documentation