### PR TITLE
#2162: Mitigate factus.update calls get stuck if server runs into database issues

### DIFF
--- a/factcast-itests/factcast-itests-factus/src/test/java/org/factcast/itests/factus/client/DatabaseUnhealthyITest.java
+++ b/factcast-itests/factcast-itests-factus/src/test/java/org/factcast/itests/factus/client/DatabaseUnhealthyITest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2017-2022 factcast.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.factcast.itests.factus.client;
+
+import static java.util.concurrent.TimeUnit.*;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import eu.rekawek.toxiproxy.model.ToxicDirection;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.factcast.factus.Factus;
+import org.factcast.factus.Handler;
+import org.factcast.factus.projection.LocalManagedProjection;
+import org.factcast.factus.serializer.ProjectionMetaData;
+import org.factcast.itests.TestFactusApplication;
+import org.factcast.itests.factus.event.UserCreated;
+import org.factcast.test.AbstractFactCastIntegrationTest;
+import org.factcast.test.toxi.PostgresqlProxy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+
+@SpringBootTest
+@ContextConfiguration(classes = TestFactusApplication.class)
+@Slf4j
+class DatabaseUnhealthyITest extends AbstractFactCastIntegrationTest {
+  @Autowired Factus factus;
+  PostgresqlProxy proxy;
+
+  @BeforeEach
+  void setup() {
+    log.info("Publishing");
+    factus.publish(new UserCreated("dieter"));
+  }
+
+  @SneakyThrows
+  @Test
+  @Timeout(value = 5, unit = SECONDS)
+  void testFactusGetsStuckIssue2162() {
+
+    final var userProjection = new UserProjection();
+
+    proxy.toxics().resetPeer("db-gone", ToxicDirection.UPSTREAM, 1000);
+
+    new Timer()
+        .schedule(
+            new TimerTask() {
+              @Override
+              public void run() {
+                // heal the communication
+                log.info("repairing proxy");
+                proxy.reset();
+              }
+            },
+            2000);
+
+    assertThatThrownBy(() -> factus.update(userProjection)).isInstanceOf(Exception.class);
+  }
+
+  @ProjectionMetaData(serial = 1)
+  static class UserProjection extends LocalManagedProjection {
+
+    @Handler
+    void apply(UserCreated e) {
+      // do something
+    }
+  }
+}

--- a/factcast-server-grpc/src/main/java/org/factcast/server/grpc/GrpcServerExceptionInterceptor.java
+++ b/factcast-server-grpc/src/main/java/org/factcast/server/grpc/GrpcServerExceptionInterceptor.java
@@ -61,7 +61,7 @@ public class GrpcServerExceptionInterceptor implements ServerInterceptor {
     public void onReady() {
       try {
         super.onReady();
-      } catch (RuntimeException ex) {
+      } catch (Exception ex) {
         handleException(ex, serverCall, metadata);
       }
     }
@@ -70,7 +70,7 @@ public class GrpcServerExceptionInterceptor implements ServerInterceptor {
     public void onCancel() {
       try {
         super.onCancel();
-      } catch (RuntimeException ex) {
+      } catch (Exception ex) {
         handleException(ex, serverCall, metadata);
       }
     }
@@ -79,7 +79,7 @@ public class GrpcServerExceptionInterceptor implements ServerInterceptor {
     public void onComplete() {
       try {
         super.onComplete();
-      } catch (RuntimeException ex) {
+      } catch (Exception ex) {
         handleException(ex, serverCall, metadata);
       }
     }
@@ -88,7 +88,7 @@ public class GrpcServerExceptionInterceptor implements ServerInterceptor {
     public void onMessage(ReqT message) {
       try {
         super.onMessage(message);
-      } catch (RuntimeException ex) {
+      } catch (Exception ex) {
         handleException(ex, serverCall, metadata);
       }
     }
@@ -97,14 +97,14 @@ public class GrpcServerExceptionInterceptor implements ServerInterceptor {
     public void onHalfClose() {
       try {
         super.onHalfClose();
-      } catch (RuntimeException ex) {
+      } catch (Exception ex) {
         handleException(ex, serverCall, metadata);
       }
     }
 
     @VisibleForTesting
     void handleException(
-        RuntimeException exception, ServerCall<ReqT, RespT> serverCall, Metadata metadata) {
+        Exception exception, ServerCall<ReqT, RespT> serverCall, Metadata metadata) {
 
       if (exception instanceof RequestCanceledByClientException) {
         // maybe we can even skip this close call?
@@ -130,7 +130,7 @@ public class GrpcServerExceptionInterceptor implements ServerInterceptor {
     }
 
     @VisibleForTesting
-    protected void logIfNecessary(@NonNull Logger logger, @NonNull RuntimeException exception) {
+    protected void logIfNecessary(@NonNull Logger logger, @NonNull Exception exception) {
       String clientId = grpcMetadata.clientIdAsString();
       if (exception instanceof FactValidationException) {
         logger.warn("Exception triggered by client '{}':", clientId, exception);

--- a/factcast-store/src/main/java/org/factcast/store/internal/PgSubscriptionFactory.java
+++ b/factcast-store/src/main/java/org/factcast/store/internal/PgSubscriptionFactory.java
@@ -92,7 +92,7 @@ class PgSubscriptionFactory {
         warnAndNotify(subscription, req, "missing transformation", e);
       } catch (TransformationException e) {
         errorAndNotify(subscription, req, "failing transformation", e);
-      } catch (RuntimeException e) {
+      } catch (Exception e) {
         // warn level because it is unexpected and unlikely to be a client induced error
         // not limiting to RuntimeException, in case anyone used @SneakyThrows
         warnAndNotify(subscription, req, "runtime", e);

--- a/factcast-store/src/main/java/org/factcast/store/internal/query/PgLatestSerialFetcher.java
+++ b/factcast-store/src/main/java/org/factcast/store/internal/query/PgLatestSerialFetcher.java
@@ -36,14 +36,12 @@ public class PgLatestSerialFetcher {
   /** @return 0, if no Fact is found, or exception is raised. */
   public long retrieveLatestSer() {
     // noinspection CatchMayIgnoreException
-    try {
-      SqlRowSet rs = jdbcTemplate.queryForRowSet(PgConstants.LAST_SERIAL_IN_LOG);
-      if (rs.next()) {
-        return rs.getLong(1);
-      }
-    } catch (Exception ignored) {
-      log.warn("While retrieveLatestSer:", ignored);
+
+    SqlRowSet rs = jdbcTemplate.queryForRowSet(PgConstants.LAST_SERIAL_IN_LOG);
+    if (rs.next()) {
+      return rs.getLong(1);
     }
+
     return 0;
   }
 }

--- a/factcast-store/src/main/java/org/factcast/store/internal/query/PgLatestSerialFetcher.java
+++ b/factcast-store/src/main/java/org/factcast/store/internal/query/PgLatestSerialFetcher.java
@@ -35,8 +35,6 @@ public class PgLatestSerialFetcher {
 
   /** @return 0, if no Fact is found, or exception is raised. */
   public long retrieveLatestSer() {
-    // noinspection CatchMayIgnoreException
-
     SqlRowSet rs = jdbcTemplate.queryForRowSet(PgConstants.LAST_SERIAL_IN_LOG);
     if (rs.next()) {
       return rs.getLong(1);

--- a/factcast-store/src/test/java/org/factcast/store/internal/PgLatestSerialFetcherTest.java
+++ b/factcast-store/src/test/java/org/factcast/store/internal/PgLatestSerialFetcherTest.java
@@ -16,7 +16,6 @@
 package org.factcast.store.internal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 import java.util.*;
@@ -25,7 +24,6 @@ import org.factcast.test.IntegrationTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.jdbc.Sql;
@@ -79,13 +77,5 @@ public class PgLatestSerialFetcherTest {
             + UUID.randomUUID()
             + "\", \"ns\":\"hups\"}','{}') ");
     assertEquals(3, uut.retrieveLatestSer());
-  }
-
-  @Test
-  void testRetrieveLatestSerWithException() {
-    JdbcTemplate jdbcMock = mock(JdbcTemplate.class);
-    when(jdbcMock.queryForRowSet(anyString())).thenThrow(new EmptyResultDataAccessException(1));
-    uut = new PgLatestSerialFetcher(jdbcMock);
-    assertEquals(0, uut.retrieveLatestSer());
   }
 }

--- a/factcast-store/src/test/java/org/factcast/store/internal/query/PgLatestSerialFetcherTest.java
+++ b/factcast-store/src/test/java/org/factcast/store/internal/query/PgLatestSerialFetcherTest.java
@@ -36,12 +36,6 @@ public class PgLatestSerialFetcherTest {
   @Mock SqlRowSet rs;
 
   @Test
-  public void testRetrieveLatestSerRetuns0WhenExceptionThrown() {
-    when(jdbc.queryForRowSet(anyString())).thenThrow(UnsupportedOperationException.class);
-    assertEquals(0, uut.retrieveLatestSer());
-  }
-
-  @Test
   public void shouldReturn0IfNotFound() {
     when(jdbc.queryForRowSet(anyString())).thenReturn(rs);
     when(rs.next()).thenReturn(false);


### PR DESCRIPTION
We observed two more occasions of the issue described in #2162.
This time the pattern was easy to identify: it always happened when the postgres (RDS) was not available/caused some kind of `PSQLException` within factcast. In our case this happened due to DB maintenance.

This way I could create a failing test by leveraging our toxiproxy setup. 

We identified two main issues:
- in `PgSubscriptionFactory.java` we catch RuntimeExceptions but the exception from above is none. The client was never notified about an error -> will now be mapped to StatusRuntimeException UNKNOWN
- `PgLatestSerialFetcher.java` swallows just every exception but is used to create the `FactStreamInfo` -> since we use `COALESCE` in our case I think the exception handling is not necessary at this place

Im not quite sure if there arent more places affected but at least the `factus.update` call now throws an exception and does not get stuck forever.


Closes #2162