### PR TITLE
2052: remove unused transitive codec dependencies

### DIFF
--- a/factcast-snapshotcache-redisson/pom.xml
+++ b/factcast-snapshotcache-redisson/pom.xml
@@ -71,42 +71,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.esotericsoftware</groupId>
-      <artifactId>kryo</artifactId>
-      <version>5.4.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.esotericsoftware.kryo</groupId>
-      <artifactId>kryo5</artifactId>
-      <version>5.4.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.dataformat</groupId>
-      <artifactId>jackson-dataformat-smile</artifactId>
-      <version>2.14.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.dataformat</groupId>
-      <artifactId>jackson-dataformat-cbor</artifactId>
-      <version>2.14.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.msgpack</groupId>
-      <artifactId>jackson-dataformat-msgpack</artifactId>
-      <version>0.9.3</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.dataformat</groupId>
-      <artifactId>jackson-dataformat-ion</artifactId>
-      <version>2.14.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>net.jpountz.lz4</groupId>
       <artifactId>lz4</artifactId>
       <version>1.3.0</version>

--- a/factcast-snapshotcache-redisson/src/main/java/org/factcast/core/snap/redisson/RedissonSnapshotProperties.java
+++ b/factcast-snapshotcache-redisson/src/main/java/org/factcast/core/snap/redisson/RedissonSnapshotProperties.java
@@ -56,19 +56,19 @@ public class RedissonSnapshotProperties {
     /** When setting the codec to RedissonDefault, factcast will not specify a codec. */
     RedissonDefault(null),
     @SuppressWarnings("deprecation")
-    MarshallingCodec(MarshallingCodec::new),
-    Kryo5Codec(Kryo5Codec::new),
-    JsonJacksonCodec(JsonJacksonCodec::new),
-    SmileJacksonCodec(SmileJacksonCodec::new),
-    CborJacksonCodec(CborJacksonCodec::new),
-    MsgPackJacksonCodec(MsgPackJacksonCodec::new),
-    IonJacksonCodec(IonJacksonCodec::new),
-    SerializationCodec(SerializationCodec::new),
-    LZ4Codec(LZ4Codec::new),
-    SnappyCodecV2(SnappyCodecV2::new),
-    StringCodec(StringCodec::new),
-    LongCodec(LongCodec::new),
-    ByteArrayCodec(ByteArrayCodec::new);
+    MarshallingCodec(() -> new MarshallingCodec()),
+    Kryo5Codec(() -> new Kryo5Codec()),
+    JsonJacksonCodec(() -> new JsonJacksonCodec()),
+    SmileJacksonCodec(() -> new SmileJacksonCodec()),
+    CborJacksonCodec(() -> new CborJacksonCodec()),
+    MsgPackJacksonCodec(() -> new MsgPackJacksonCodec()),
+    IonJacksonCodec(() -> new IonJacksonCodec()),
+    SerializationCodec(() -> new SerializationCodec()),
+    LZ4Codec(() -> new LZ4Codec()),
+    SnappyCodecV2(() -> new SnappyCodecV2()),
+    StringCodec(() -> new StringCodec()),
+    LongCodec(() -> new LongCodec()),
+    ByteArrayCodec(() -> new ByteArrayCodec());
     // Support might be added: https://github.com/factcast/factcast/issues/2231
     // TypedJsonJacksonCodec,
     // CompositeCodec


### PR DESCRIPTION
Against expectations java ignores the lazy class loading when using the method reference operator instead of a lambda which is why building fails for clients using the newest version because of missing dependencies. 
This PR reverts that and removes the now not longer required test dependencies.