### PR TITLE
Redis tx callbacks

### DIFF
--- a/factcast-factus-redis/src/main/java/org/factcast/factus/redis/AbstractRedisSubscribedProjection.java
+++ b/factcast-factus-redis/src/main/java/org/factcast/factus/redis/AbstractRedisSubscribedProjection.java
@@ -17,11 +17,72 @@ package org.factcast.factus.redis;
 
 import lombok.NonNull;
 import org.factcast.factus.projection.SubscribedProjection;
+import org.factcast.factus.redis.tx.EnableRedisTransactionCallbacks;
+import org.factcast.factus.redis.tx.RedisTransactional;
+import org.factcast.factus.redis.tx.TransactionNotificationMessages;
 import org.redisson.api.RedissonClient;
 
 public abstract class AbstractRedisSubscribedProjection extends AbstractRedisProjection
     implements SubscribedProjection {
+
   public AbstractRedisSubscribedProjection(@NonNull RedissonClient redisson) {
     super(redisson);
+
+    subscribeToTransactionNotificationIfEnabled();
+  }
+
+  private void subscribeToTransactionNotificationIfEnabled() {
+
+    if (getClass().getAnnotation(EnableRedisTransactionCallbacks.class) == null
+        || getClass().getAnnotation(RedisTransactional.class) == null) {
+      return;
+    }
+
+    getLogger().debug("Registering to receive commit and rollback notifications.");
+
+    redisson()
+        .getTopic(TransactionNotificationMessages.getTopicName(this))
+        .addListener(
+            String.class,
+            (channel, code) -> {
+              switch (TransactionNotificationMessages.fromCode(code)) {
+                case COMMIT:
+                  onCommit();
+                  break;
+
+                case ROLLBACK:
+                  onRollback();
+                  break;
+
+                default:
+                  getLogger()
+                      .warn(
+                          "Received unknown code {} from channel {} in transaction notification subscription.",
+                          code,
+                          channel);
+              }
+            });
+  }
+
+  /**
+   * <b>Will only be called when the projection is annotated with <code>
+   * @EnableRedisTransactionCallbacks</code>!</b>
+   *
+   * <p>Invoked when a transaction was successfully committed, no matter if this instance is
+   * processing events, or another one. Can be used to update internal caches from redis on all
+   * instances, after the data in redis got updated by new events.
+   */
+  public void onCommit() {
+    // default: do nothing
+  }
+
+  /**
+   * <b>Will only be called when the projection is annotated with <code>
+   * @EnableRedisTransactionCallbacks</code>!</b>
+   *
+   * <p>Invoked when a transaction was rolled back. Unfortunately we do not have more context.
+   */
+  public void onRollback() {
+    // default: do nothing
   }
 }

--- a/factcast-factus-redis/src/main/java/org/factcast/factus/redis/tx/EnableRedisTransactionCallbacks.java
+++ b/factcast-factus-redis/src/main/java/org/factcast/factus/redis/tx/EnableRedisTransactionCallbacks.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2017-2023 factcast.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.factcast.factus.redis.tx;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.factcast.factus.redis.AbstractRedisSubscribedProjection;
+
+/**
+ * Only works on subclasses of {@link org.factcast.factus.redis.AbstractRedisSubscribedProjection}.
+ *
+ * <p>Enables that the methods {@link AbstractRedisSubscribedProjection#onCommit()} and {@link
+ * AbstractRedisSubscribedProjection#onRollback()} will be invoked when the tx manager commits or
+ * rolls back.
+ *
+ * <p>Attention, in case you are adding this to projections that are already deployed, it would be
+ * safer to increase the serial of the projection. Otherwise, during the first deployment, some
+ * updates might get lost when the instance that processes does not have this annotation, and the
+ * newly deployed instances do not have the lock but expect the callbacks.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Inherited
+public @interface EnableRedisTransactionCallbacks {}

--- a/factcast-factus-redis/src/main/java/org/factcast/factus/redis/tx/RedisTransactionalLens.java
+++ b/factcast-factus-redis/src/main/java/org/factcast/factus/redis/tx/RedisTransactionalLens.java
@@ -92,19 +92,6 @@ public class RedisTransactionalLens extends AbstractTransactionalLens {
   }
 
   @VisibleForTesting
-  static TransactionOptions createOpts(@NonNull RedisProjection p) {
-    RedisTransactional transactional = p.getClass().getAnnotation(RedisTransactional.class);
-    if (transactional == null) {
-      throw new IllegalStateException(
-          "Projection "
-              + p.getClass()
-              + " is expected to have an annotation @"
-              + RedisTransactional.class.getSimpleName());
-    }
-    return Defaults.with(transactional);
-  }
-
-  @VisibleForTesting
   static int getSize(@NonNull RedisProjection p) {
     RedisTransactional transactional = p.getClass().getAnnotation(RedisTransactional.class);
     if (transactional == null) {
@@ -115,6 +102,19 @@ public class RedisTransactionalLens extends AbstractTransactionalLens {
               + RedisTransactional.class.getSimpleName());
     }
     return transactional.bulkSize();
+  }
+
+  @VisibleForTesting
+  static TransactionOptions createOpts(@NonNull RedisProjection p) {
+    RedisTransactional transactional = p.getClass().getAnnotation(RedisTransactional.class);
+    if (transactional == null) {
+      throw new IllegalStateException(
+          "Projection "
+              + p.getClass()
+              + " is expected to have an annotation @"
+              + RedisTransactional.class.getSimpleName());
+    }
+    return Defaults.with(transactional);
   }
 
   @VisibleForTesting

--- a/factcast-factus-redis/src/main/java/org/factcast/factus/redis/tx/TransactionNotificationMessages.java
+++ b/factcast-factus-redis/src/main/java/org/factcast/factus/redis/tx/TransactionNotificationMessages.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2017-2023 factcast.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.factcast.factus.redis.tx;
+
+import com.google.common.annotations.VisibleForTesting;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.factcast.factus.redis.AbstractRedisSubscribedProjection;
+
+@Getter
+@RequiredArgsConstructor
+public enum TransactionNotificationMessages {
+  COMMIT("c"),
+  ROLLBACK("r");
+
+  @VisibleForTesting
+  public static final String NOTIFICATION_TOPIC_POSTFIX = "_redis_transactional_notification";
+
+  @NonNull private final String code;
+
+  /**
+   * @param p the redis projection for which we need the topic name
+   * @return the full name of the topic into which we write the messages for this projection
+   */
+  public static String getTopicName(AbstractRedisSubscribedProjection p) {
+    return p.getScopedName().with(NOTIFICATION_TOPIC_POSTFIX).asString();
+  }
+
+  public static TransactionNotificationMessages fromCode(String code) {
+    for (TransactionNotificationMessages message : values()) {
+      if (message.code.equals(code)) {
+        return message;
+      }
+    }
+    throw new IllegalArgumentException("Unknown code " + code);
+  }
+}

--- a/factcast-factus-redis/src/test/java/org/factcast/factus/redis/AbstractRedisSubscribedProjectionTest.java
+++ b/factcast-factus-redis/src/test/java/org/factcast/factus/redis/AbstractRedisSubscribedProjectionTest.java
@@ -77,8 +77,8 @@ class AbstractRedisSubscribedProjectionTest {
     @Test
     void commit() {
       // INIT
-      assertThat(underTest.numberCommits()).isEqualTo(0);
-      assertThat(underTest.numberRollbacks()).isEqualTo(0);
+      assertThat(underTest.numberCommits()).isZero();
+      assertThat(underTest.numberRollbacks()).isZero();
 
       // RUN
       // emulate we got a notification from redis
@@ -86,21 +86,21 @@ class AbstractRedisSubscribedProjectionTest {
 
       // ASSERT
       assertThat(underTest.numberCommits()).isEqualTo(1);
-      assertThat(underTest.numberRollbacks()).isEqualTo(0);
+      assertThat(underTest.numberRollbacks()).isZero();
     }
 
     @Test
     void rollBack() {
       // INIT
-      assertThat(underTest.numberCommits()).isEqualTo(0);
-      assertThat(underTest.numberRollbacks()).isEqualTo(0);
+      assertThat(underTest.numberCommits()).isZero();
+      assertThat(underTest.numberRollbacks()).isZero();
 
       // RUN
       // emulate we got a notification from redis
       listener.onMessage("", ROLLBACK.code());
 
       // ASSERT
-      assertThat(underTest.numberCommits()).isEqualTo(0);
+      assertThat(underTest.numberCommits()).isZero();
       assertThat(underTest.numberRollbacks()).isEqualTo(1);
     }
   }

--- a/factcast-factus-redis/src/test/java/org/factcast/factus/redis/AbstractRedisSubscribedProjectionTest.java
+++ b/factcast-factus-redis/src/test/java/org/factcast/factus/redis/AbstractRedisSubscribedProjectionTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright © 2017-2023 factcast.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.factcast.factus.redis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.factcast.factus.redis.tx.TransactionNotificationMessages.COMMIT;
+import static org.factcast.factus.redis.tx.TransactionNotificationMessages.NOTIFICATION_TOPIC_POSTFIX;
+import static org.factcast.factus.redis.tx.TransactionNotificationMessages.ROLLBACK;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.endsWith;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import lombok.Getter;
+import lombok.NonNull;
+import org.factcast.factus.redis.tx.EnableRedisTransactionCallbacks;
+import org.factcast.factus.redis.tx.RedisTransactional;
+import org.factcast.factus.serializer.ProjectionMetaData;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.redisson.api.RTopic;
+import org.redisson.api.RedissonClient;
+import org.redisson.api.listener.MessageListener;
+
+@ExtendWith(MockitoExtension.class)
+class AbstractRedisSubscribedProjectionTest {
+
+  @Mock RedissonClient client;
+
+  @Nested
+  class WithCallbacksEnabled {
+    RedisSubscribedProjectionWithCallbacks underTest;
+    @Mock RTopic topic;
+
+    MessageListener<String> listener;
+
+    @BeforeEach
+    void setup() {
+      when(client.getTopic(endsWith(NOTIFICATION_TOPIC_POSTFIX))).thenReturn(topic);
+
+      when(topic.addListener(eq(String.class), any()))
+          .thenAnswer(
+              inv -> {
+                //noinspection unchecked
+                listener = inv.getArgument(1, MessageListener.class);
+                return null;
+              });
+
+      // only invoke after client and topic got mocked!
+      underTest = new RedisSubscribedProjectionWithCallbacks(client);
+
+      verify(client).getTopic(any());
+      verify(topic).addListener(any(), any());
+
+      assertThat(listener).isNotNull();
+    }
+
+    @Test
+    void commit() {
+      // INIT
+      assertThat(underTest.numberCommits()).isEqualTo(0);
+      assertThat(underTest.numberRollbacks()).isEqualTo(0);
+
+      // RUN
+      // emulate we got a notification from redis
+      listener.onMessage("", COMMIT.code());
+
+      // ASSERT
+      assertThat(underTest.numberCommits()).isEqualTo(1);
+      assertThat(underTest.numberRollbacks()).isEqualTo(0);
+    }
+
+    @Test
+    void rollBack() {
+      // INIT
+      assertThat(underTest.numberCommits()).isEqualTo(0);
+      assertThat(underTest.numberRollbacks()).isEqualTo(0);
+
+      // RUN
+      // emulate we got a notification from redis
+      listener.onMessage("", ROLLBACK.code());
+
+      // ASSERT
+      assertThat(underTest.numberCommits()).isEqualTo(0);
+      assertThat(underTest.numberRollbacks()).isEqualTo(1);
+    }
+  }
+
+  @Test
+  void doesNotRegisterWithoutAnnotation() {
+    RedisSubscribedProjectionWithoutCallbacks p =
+        new RedisSubscribedProjectionWithoutCallbacks(client);
+
+    // should not register on topic
+    verify(client, never()).getTopic(any());
+    verify(client, never()).getTopic(any(), any());
+  }
+
+  @Getter
+  @RedisTransactional
+  @ProjectionMetaData(serial = 1)
+  @EnableRedisTransactionCallbacks
+  class RedisSubscribedProjectionWithCallbacks extends AbstractRedisSubscribedProjection {
+    int numberCommits = 0;
+    int numberRollbacks = 0;
+
+    RedisSubscribedProjectionWithCallbacks(@NonNull RedissonClient redisson) {
+      super(redisson);
+    }
+
+    @Override
+    public void onCommit() {
+      numberCommits++;
+    }
+
+    @Override
+    public void onRollback() {
+      numberRollbacks++;
+    }
+  }
+
+  @Getter
+  @RedisTransactional
+  @ProjectionMetaData(serial = 1)
+  class RedisSubscribedProjectionWithoutCallbacks extends AbstractRedisSubscribedProjection {
+    int numberCommits = 0;
+    int numberRollbacks = 0;
+
+    RedisSubscribedProjectionWithoutCallbacks(@NonNull RedissonClient redisson) {
+      super(redisson);
+    }
+
+    @Override
+    public void onCommit() {
+      numberCommits++;
+    }
+
+    @Override
+    public void onRollback() {
+      numberRollbacks++;
+    }
+  }
+}

--- a/factcast-itests/factcast-itests-factus/src/test/java/org/factcast/itests/factus/client/RedisTransactionalITest.java
+++ b/factcast-itests/factcast-itests-factus/src/test/java/org/factcast/itests/factus/client/RedisTransactionalITest.java
@@ -162,7 +162,7 @@ public class RedisTransactionalITest extends AbstractFactCastIntegrationTest {
 
       assertThat(p.userNames().size()).isEqualTo(NUMBER_OF_EVENTS);
       assertThat(p.stateModifications()).isEqualTo(2); // one for timeout, one for final flush
-      awaitCommits(p, 1);
+      awaitCommits(p, 2);
       awaitRollbacks(p, 0);
     }
 


### PR DESCRIPTION
Provide a way for `@RedisTransactional` enabled subscribed projections to receive callbacks for commit and rollbacks of the redis transaction.

Enable on projection via `@EnableRedisTransactionCallbacks`.

Only works when projection is subclass of
`AbstractRedisSubscribedProjection`, and is annotated with `@RedisTransactional`.

Overwrite `onCommit` and `onRollback` to receive the notifications.