### PR TITLE
Add dependency declaring interface in order to ensure init/destroy order in Spring

### DIFF
--- a/factcast-factus/src/main/java/org/factcast/factus/utils/FactusDependency.java
+++ b/factcast-factus/src/main/java/org/factcast/factus/utils/FactusDependency.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2017-2023 factcast.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.factcast.factus.utils;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * used to mark components that Factus depends on, so that the necessary order of bean
+ * creation/destruction can be derived.
+ */
+public interface FactusDependency {
+  static FactusDependency on(@NonNull Object obj) {
+    return new FactusDependencyReference(obj);
+  }
+
+  @RequiredArgsConstructor
+  class FactusDependencyReference implements FactusDependency {
+    final Object reference;
+  }
+}

--- a/factcast-spring-boot-autoconfigure/src/main/java/org/factcast/spring/boot/autoconfigure/core/RedissonAutoConfiguration.java
+++ b/factcast-spring-boot-autoconfigure/src/main/java/org/factcast/spring/boot/autoconfigure/core/RedissonAutoConfiguration.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2017-2020 factcast.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.factcast.spring.boot.autoconfigure.core;
+
+import org.factcast.factus.utils.FactusDependency;
+import org.redisson.api.RedissonClient;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Bean;
+
+@AutoConfiguration
+@ConditionalOnClass({RedissonClient.class})
+public class RedissonAutoConfiguration {
+
+  @Bean
+  public FactusDependency redissonClientDependency(RedissonClient redisson) {
+    return FactusDependency.on(redisson);
+  }
+}

--- a/factcast-spring-boot-autoconfigure/src/main/java/org/factcast/spring/boot/autoconfigure/factus/FactusAutoConfiguration.java
+++ b/factcast-spring-boot-autoconfigure/src/main/java/org/factcast/spring/boot/autoconfigure/factus/FactusAutoConfiguration.java
@@ -16,6 +16,7 @@
 package org.factcast.spring.boot.autoconfigure.factus;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import java.util.*;
 import lombok.Generated;
 import lombok.extern.slf4j.Slf4j;
 import org.factcast.core.FactCast;
@@ -33,6 +34,7 @@ import org.factcast.factus.serializer.SnapshotSerializer;
 import org.factcast.factus.snapshot.AggregateSnapshotRepositoryImpl;
 import org.factcast.factus.snapshot.ProjectionSnapshotRepositoryImpl;
 import org.factcast.factus.snapshot.SnapshotSerializerSupplier;
+import org.factcast.factus.utils.FactusDependency;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureOrder;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -58,6 +60,8 @@ public class FactusAutoConfiguration {
       EventConverter eventConverter,
       SnapshotSerializerSupplier snapshotSerializerSupplier,
       FactusMetrics factusMetrics,
+      /** not used but part of the constructor to ensure the dependency graph can be inspected */
+      @SuppressWarnings("unused") Set<FactusDependency> dependencies,
       ProjectorFactory projectorFactory) {
     return new FactusImpl(
         fc,

--- a/factcast-spring-boot-autoconfigure/src/main/java/org/factcast/spring/boot/autoconfigure/factus/FactusAutoConfiguration.java
+++ b/factcast-spring-boot-autoconfigure/src/main/java/org/factcast/spring/boot/autoconfigure/factus/FactusAutoConfiguration.java
@@ -60,9 +60,9 @@ public class FactusAutoConfiguration {
       EventConverter eventConverter,
       SnapshotSerializerSupplier snapshotSerializerSupplier,
       FactusMetrics factusMetrics,
-      /** not used but part of the constructor to ensure the dependency graph can be inspected */
-      @SuppressWarnings("unused") Set<FactusDependency> dependencies,
-      ProjectorFactory projectorFactory) {
+      ProjectorFactory projectorFactory,
+      /** not used but part of parameters to ensure the dependency graph can be inspected */
+      @SuppressWarnings("unused") Set<FactusDependency> dependencies) {
     return new FactusImpl(
         fc,
         projectorFactory,

--- a/factcast-spring-boot-autoconfigure/src/main/java/org/factcast/spring/boot/autoconfigure/redis/RedissonAutoConfiguration.java
+++ b/factcast-spring-boot-autoconfigure/src/main/java/org/factcast/spring/boot/autoconfigure/redis/RedissonAutoConfiguration.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.factcast.spring.boot.autoconfigure.core;
+package org.factcast.spring.boot.autoconfigure.redis;
 
 import org.factcast.factus.utils.FactusDependency;
 import org.redisson.api.RedissonClient;

--- a/factcast-spring-boot-autoconfigure/src/main/java/org/factcast/spring/boot/autoconfigure/redis/RedissonAutoConfiguration.java
+++ b/factcast-spring-boot-autoconfigure/src/main/java/org/factcast/spring/boot/autoconfigure/redis/RedissonAutoConfiguration.java
@@ -18,11 +18,11 @@ package org.factcast.spring.boot.autoconfigure.redis;
 import org.factcast.factus.utils.FactusDependency;
 import org.redisson.api.RedissonClient;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.context.annotation.Bean;
 
 @AutoConfiguration
-@ConditionalOnClass({RedissonClient.class})
+@ConditionalOnBean({RedissonClient.class})
 public class RedissonAutoConfiguration {
 
   @Bean

--- a/factcast-spring-boot-autoconfigure/src/main/java/org/factcast/spring/boot/autoconfigure/redis/RedissonSnapshotCacheAutoConfiguration.java
+++ b/factcast-spring-boot-autoconfigure/src/main/java/org/factcast/spring/boot/autoconfigure/redis/RedissonSnapshotCacheAutoConfiguration.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.factcast.spring.boot.autoconfigure.core;
+package org.factcast.spring.boot.autoconfigure.redis;
 
 import lombok.Generated;
 import lombok.NonNull;

--- a/factcast-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/factcast-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,6 +1,7 @@
 org.factcast.spring.boot.autoconfigure.core.FactCastAutoConfiguration
 org.factcast.spring.boot.autoconfigure.core.FactCastSnapshotCacheAutoConfiguration
-org.factcast.spring.boot.autoconfigure.core.RedissonSnapshotCacheAutoConfiguration
+org.factcast.spring.boot.autoconfigure.redis.RedissonSnapshotCacheAutoConfiguration
+org.factcast.spring.boot.autoconfigure.redis.RedissonAutoConfiguration
 org.factcast.spring.boot.autoconfigure.factus.FactusAutoConfiguration
 org.factcast.spring.boot.autoconfigure.factus.BinaryJacksonSnapshotSerializerAutoConfiguration
 org.factcast.spring.boot.autoconfigure.client.grpc.GrpcFactStoreAutoConfiguration


### PR DESCRIPTION
closes #2381 
superseeds #2383 

This way, people can either implement, or use an indirection (see RedissonAutoConfiguration as an example)  to declare dependencies to Factus the Spring way, without necessarily changing Factcast code.