### PR TITLE
#2931 fail fast on missing credential parts

### DIFF
--- a/factcast-client-grpc/src/test/java/org/factcast/client/grpc/GrpcFactStoreTest.java
+++ b/factcast-client-grpc/src/test/java/org/factcast/client/grpc/GrpcFactStoreTest.java
@@ -536,6 +536,84 @@ class GrpcFactStoreTest {
     }
 
     @Test
+    void testNewCredentialsNoPassword() {
+      when(blockingStub.withWaitForReady()).thenReturn(blockingStub);
+      when(stub.withWaitForReady()).thenReturn(stub);
+
+      credentials = Optional.empty();
+      final FactCastGrpcClientProperties props = new FactCastGrpcClientProperties();
+      props.setUser("user");
+
+      GrpcFactStore uutNewCredentials =
+          new GrpcFactStore(channel, stubsFactory, credentials, props, "foo");
+
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> {
+            uutNewCredentials.initializeIfNecessary();
+          });
+    }
+
+    @Test
+    void testNewCredentialsEmptyPassword() {
+      when(blockingStub.withWaitForReady()).thenReturn(blockingStub);
+      when(stub.withWaitForReady()).thenReturn(stub);
+
+      credentials = Optional.empty();
+      final FactCastGrpcClientProperties props = new FactCastGrpcClientProperties();
+      props.setUser("user");
+      props.setPassword("");
+
+      GrpcFactStore uutNewCredentials =
+          new GrpcFactStore(channel, stubsFactory, credentials, props, "foo");
+
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> {
+            uutNewCredentials.initializeIfNecessary();
+          });
+    }
+
+    @Test
+    void testNewCredentialsNoUsername() {
+      when(blockingStub.withWaitForReady()).thenReturn(blockingStub);
+      when(stub.withWaitForReady()).thenReturn(stub);
+
+      credentials = Optional.empty();
+      final FactCastGrpcClientProperties props = new FactCastGrpcClientProperties();
+      props.setPassword("password");
+
+      GrpcFactStore uutNewCredentials =
+          new GrpcFactStore(channel, stubsFactory, credentials, props, "foo");
+
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> {
+            uutNewCredentials.initializeIfNecessary();
+          });
+    }
+
+    @Test
+    void testNewCredentialsEmptyUsername() {
+      when(blockingStub.withWaitForReady()).thenReturn(blockingStub);
+      when(stub.withWaitForReady()).thenReturn(stub);
+
+      credentials = Optional.empty();
+      final FactCastGrpcClientProperties props = new FactCastGrpcClientProperties();
+      props.setUser("");
+      props.setPassword("password");
+
+      GrpcFactStore uutNewCredentials =
+          new GrpcFactStore(channel, stubsFactory, credentials, props, "foo");
+
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> {
+            uutNewCredentials.initializeIfNecessary();
+          });
+    }
+
+    @Test
     void testLegacyCredentials() {
       final FactCastGrpcClientProperties props = new FactCastGrpcClientProperties();
 
@@ -545,6 +623,36 @@ class GrpcFactStoreTest {
 
       verify(blockingStub).withCallCredentials(any());
       verify(stub).withCallCredentials(any());
+    }
+
+    @Test
+    void testLegacyCredentialsEmptyUsername() {
+      when(blockingStub.withWaitForReady()).thenReturn(blockingStub);
+      when(stub.withWaitForReady()).thenReturn(stub);
+
+      credentials = Optional.of(":abc");
+      final FactCastGrpcClientProperties props = new FactCastGrpcClientProperties();
+
+      GrpcFactStore uutLegacyCredentials =
+          new GrpcFactStore(channel, stubsFactory, credentials, props, "foo");
+
+      assertThrows(
+          IllegalArgumentException.class, () -> uutLegacyCredentials.initializeIfNecessary());
+    }
+
+    @Test
+    void testLegacyCredentialsEmptyPassword() {
+      when(blockingStub.withWaitForReady()).thenReturn(blockingStub);
+      when(stub.withWaitForReady()).thenReturn(stub);
+
+      credentials = Optional.of("xyz:");
+      final FactCastGrpcClientProperties props = new FactCastGrpcClientProperties();
+
+      GrpcFactStore uutLegacyCredentials =
+          new GrpcFactStore(channel, stubsFactory, credentials, props, "foo");
+
+      assertThrows(
+          IllegalArgumentException.class, () -> uutLegacyCredentials.initializeIfNecessary());
     }
   }
 


### PR DESCRIPTION
Missing (and, as discussed with @uweschaefer, also empty) credential parts should cause fast failure on the client side.