### PR TITLE
issue3093 disable React support

### DIFF
--- a/factcast-server-ui/src/main/java/org/factcast/server/ui/config/UIConfiguration.java
+++ b/factcast-server-ui/src/main/java/org/factcast/server/ui/config/UIConfiguration.java
@@ -21,7 +21,9 @@ import com.vaadin.flow.spring.security.AuthenticationContext;
 import com.vaadin.flow.theme.Theme;
 import io.micrometer.core.aop.TimedAspect;
 import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.factcast.core.store.FactStore;
 import org.factcast.server.ui.adapter.FactRepositoryImpl;
 import org.factcast.server.ui.metrics.MeterRegistryMetrics;
@@ -41,7 +43,11 @@ import org.springframework.context.annotation.Import;
 @EnableVaadin("org.factcast.server.ui")
 @RequiredArgsConstructor
 @Import(JsonViewPluginConfiguration.class)
+@Slf4j
 public class UIConfiguration implements AppShellConfigurator {
+
+  static final String SYSTEM_PROPERTY_VAADIN_REACT_ENABLE = "vaadin.react.enable";
+
   @Bean
   public FactRepository factRepository(FactStore fs, SecurityService securityService) {
     return new FactRepositoryImpl(fs, securityService);
@@ -68,5 +74,13 @@ public class UIConfiguration implements AppShellConfigurator {
   @ConditionalOnMissingBean
   public TimedAspect timedAspect(MeterRegistry registry) {
     return new TimedAspect(registry);
+  }
+
+  @PostConstruct
+  public void disableVaadinReactSupport() {
+    log.info(
+        "Disabling Vaadin React support via system property {}",
+        SYSTEM_PROPERTY_VAADIN_REACT_ENABLE);
+    System.setProperty(SYSTEM_PROPERTY_VAADIN_REACT_ENABLE, "false");
   }
 }

--- a/factcast-server-ui/src/test/java/org/factcast/server/ui/config/UIConfigurationIntTest.java
+++ b/factcast-server-ui/src/test/java/org/factcast/server/ui/config/UIConfigurationIntTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2017-2024 factcast.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.factcast.server.ui.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.factcast.server.ui.AbstractBrowserTest;
+import org.factcast.server.ui.example.ExampleUiServer;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(
+    classes = ExampleUiServer.class,
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class UIConfigurationIntTest extends AbstractBrowserTest {
+
+  @Test
+  void vaadinReactEnabledIsExplicitlySetToFalseViaSystemProperty() {
+    assertThat(System.getProperty(UIConfiguration.SYSTEM_PROPERTY_VAADIN_REACT_ENABLE))
+        .isEqualTo("false");
+  }
+}


### PR DESCRIPTION
See https://github.com/factcast/factcast/issues/3093

Explicitly disable Vaadin React support to reinstate share-able URLs containing filter specifics.