### PR TITLE
#3129: AbstractFactCastIntegrationTest wipes serial sequence after each test

### DIFF
--- a/factcast-itests/factcast-itests-factus/src/test/java/org/factcast/itests/factus/client/DynamoITest.java
+++ b/factcast-itests/factcast-itests-factus/src/test/java/org/factcast/itests/factus/client/DynamoITest.java
@@ -154,7 +154,7 @@ public class DynamoITest extends AbstractFactCastIntegrationTest {
     @Test
     void happyPath() {
       SubscribedUserNames p = new SubscribedUserNames(dynamoDbClient);
-      factus.subscribeAndBlock(p).awaitCatchup();
+      factus.subscribeAndBlock(p).awaitCatchup().close();
 
       assertThat(p.count()).isEqualTo(NUMBER_OF_EVENTS);
       assertThat(p.stateModifications()).isEqualTo(10);
@@ -170,7 +170,7 @@ public class DynamoITest extends AbstractFactCastIntegrationTest {
       assertThat(p.count()).isZero();
 
       try {
-        factus.subscribeAndBlock(p).awaitCatchup();
+        factus.subscribeAndBlock(p).awaitCatchup().close();
       } catch (Throwable expected) {
         // ignore
       }

--- a/factcast-itests/factcast-itests-factus/src/test/java/org/factcast/itests/factus/client/FactusClientTest.java
+++ b/factcast-itests/factcast-itests-factus/src/test/java/org/factcast/itests/factus/client/FactusClientTest.java
@@ -191,7 +191,7 @@ class FactusClientTest extends AbstractFactCastIntegrationTest {
       var sw = Stopwatch.createStarted();
       TxRedissonSubscribedUserNames p = new TxRedissonSubscribedUserNames(redissonClient);
       var sub = factus.subscribeAndBlock(p);
-      sub.awaitCatchup();
+      sub.awaitCatchup().close();
       log.info(
           "TxRedissonSubscribedUserNames {} {}",
           sw.stop().elapsed().toMillis(),
@@ -204,7 +204,7 @@ class FactusClientTest extends AbstractFactCastIntegrationTest {
       var sw = Stopwatch.createStarted();
       TxRedissonSubscribedUserNames p = new TxRedissonSubscribedUserNames(redissonClient);
       var sub = factus.subscribeAndBlock(p);
-      sub.awaitCatchup();
+      sub.awaitCatchup().close();
       log.info(
           "TxRedissonSubscribedUserNames {} {}",
           sw.stop().elapsed().toMillis(),

--- a/factcast-itests/factcast-itests-factus/src/test/java/org/factcast/itests/factus/client/SpringTransactionalITest.java
+++ b/factcast-itests/factcast-itests-factus/src/test/java/org/factcast/itests/factus/client/SpringTransactionalITest.java
@@ -226,7 +226,7 @@ public class SpringTransactionalITest extends AbstractFactCastIntegrationTest {
     @Test
     void testBulkSize3() throws Exception {
       var s = new BulkSize3Projection(platformTransactionManager, jdbcTemplate);
-      try (var sub = factus.subscribeAndBlock(s).awaitCatchup()) {
+      try (var ignored = factus.subscribeAndBlock(s).awaitCatchup()) {
 
         assertThat(s.factStreamPositionModifications()).isEqualTo(4);
         assertThat(s.txSeen()).hasSize(4);
@@ -237,7 +237,7 @@ public class SpringTransactionalITest extends AbstractFactCastIntegrationTest {
     @Test
     void testBulkSize5() throws Exception {
       var s = new BulkSize5Projection(platformTransactionManager, jdbcTemplate);
-      try (var sub = factus.subscribeAndBlock(s).awaitCatchup()) {
+      try (var ignored = factus.subscribeAndBlock(s).awaitCatchup()) {
 
         assertThat(s.factStreamPositionModifications()).isEqualTo(2);
         assertThat(s.txSeen()).hasSize(2);
@@ -245,24 +245,28 @@ public class SpringTransactionalITest extends AbstractFactCastIntegrationTest {
       }
     }
 
+    @SneakyThrows
     @Test
     void testBulkSize10() {
       var s = new BulkSize10Projection(platformTransactionManager, jdbcTemplate);
-      factus.subscribeAndBlock(s).awaitCatchup();
+      try (var ignored = factus.subscribeAndBlock(s).awaitCatchup()) {
 
-      assertThat(s.factStreamPositionModifications()).isOne();
-      assertThat(s.txSeen()).hasSize(1);
-      assertThat(getUsers()).isEqualTo(NUMBER_OF_EVENTS);
+        assertThat(s.factStreamPositionModifications()).isOne();
+        assertThat(s.txSeen()).hasSize(1);
+        assertThat(getUsers()).isEqualTo(NUMBER_OF_EVENTS);
+      }
     }
 
+    @SneakyThrows
     @Test
     void testBulkSize20() {
       var s = new BulkSize20Projection(platformTransactionManager, jdbcTemplate);
-      factus.subscribeAndBlock(s).awaitCatchup();
+      try (var ignored = factus.subscribeAndBlock(s).awaitCatchup()) {
 
-      assertThat(s.factStreamPositionModifications()).isOne();
-      assertThat(s.txSeen()).hasSize(1);
-      assertThat(getUsers()).isEqualTo(NUMBER_OF_EVENTS);
+        assertThat(s.factStreamPositionModifications()).isOne();
+        assertThat(s.txSeen()).hasSize(1);
+        assertThat(getUsers()).isEqualTo(NUMBER_OF_EVENTS);
+      }
     }
 
     @SneakyThrows
@@ -274,7 +278,7 @@ public class SpringTransactionalITest extends AbstractFactCastIntegrationTest {
       assertThat(getUsers()).isZero();
 
       try {
-        factus.subscribeAndBlock(p).awaitCatchup();
+        factus.subscribeAndBlock(p).awaitCatchup().close();
       } catch (Throwable expected) {
         // ignore
       }

--- a/factcast-test/src/main/java/org/factcast/test/BaseIntegrationTestExtension.java
+++ b/factcast-test/src/main/java/org/factcast/test/BaseIntegrationTestExtension.java
@@ -147,7 +147,7 @@ public class BaseIntegrationTestExtension implements FactCastIntegrationTestExte
               + "    FOR r IN (SELECT tablename FROM pg_tables WHERE schemaname = current_schema()"
               + " AND (NOT ((tablename like 'databasechangelog%') OR (tablename like 'qrtz%') OR"
               + " (tablename = 'schedlock')))) LOOP\n"
-              + "        EXECUTE 'TRUNCATE TABLE ' || quote_ident(r.tablename) || ' RESTART IDENTITY ';\n"
+              + "        EXECUTE 'TRUNCATE TABLE ' || quote_ident(r.tablename);\n"
               + "    END LOOP;\n"
               + "END $$;");
     }


### PR DESCRIPTION
Closes #3129 

Fix broken itests after removing serial sequence restart.