### PR TITLE
#3176: add Mockito lib as java agent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -500,6 +500,17 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>properties</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${maven-surefire-plugin.version}</version>
         <configuration>
@@ -508,7 +519,8 @@
           </includes>
           <excludedGroups>integration,uitest</excludedGroups>
           <!--suppress UnresolvedMavenProperty -->
-          <argLine>${surefire.jacoco.args}</argLine>
+          <argLine>${surefire.jacoco.args}
+            -javaagent:${org.mockito:mockito-core:jar}</argLine>
           <skip>${skipUnitTests}</skip>
           <parallel>classes</parallel>
           <threadCountClasses>8</threadCountClasses>
@@ -541,7 +553,8 @@
             <include>*</include>
           </includes>
           <!--suppress UnresolvedMavenProperty -->
-          <argLine>${failsafe.jacoco.args}</argLine>
+          <argLine>${failsafe.jacoco.args}
+            -javaagent:${org.mockito:mockito-core:jar}</argLine>
           <systemPropertyVariables>
             <postgres.version>${postgres.version}</postgres.version>
             <factcast.version>${factcast.version}</factcast.version>


### PR DESCRIPTION
Adding Mockito lib as Java agent because starting from Java 21, the [JDK restricts the ability of libraries to attach a Java agent to their own JVM](https://openjdk.org/jeps/451). As a result, the inline-mock-maker might not be able to function without an explicit setup to enable instrumentation, and the JVM will always display a warning.

Note that e.g. [CommandServiceImplTest](https://github.com/factcast/factcast/blob/master/factcast-schema-registry-cli/src/test/kotlin/org/factcast/schema/registry/cli/commands/CommandServiceImplTest.kt) uses MockK which causes the same warning but will not be fixed with the suggested solution.

MockK still has an open issue regarding this, see https://github.com/mockk/mockk/issues/1171