### PR TITLE
#3289: FastForward information might be stale but is still applied client-side

### DIFF
--- a/factcast-core/src/main/java/org/factcast/core/FactStreamPosition.java
+++ b/factcast-core/src/main/java/org/factcast/core/FactStreamPosition.java
@@ -43,4 +43,15 @@ public class FactStreamPosition {
     if (uuid == null) return null;
     else return FactStreamPosition.of(uuid, -1L);
   }
+
+  /**
+   * Checks if fsp is after the current one. Its considered being after if the `factStreamPosition`
+   * is null (no FSP yet) or when the serial of the current FSP is greater than the one given.
+   *
+   * @param factStreamPosition
+   * @return
+   */
+  public boolean isAfter(@Nullable FactStreamPosition factStreamPosition) {
+    return factStreamPosition == null || serial > factStreamPosition.serial();
+  }
 }

--- a/factcast-core/src/test/java/org/factcast/core/FactStreamPositionTest.java
+++ b/factcast-core/src/test/java/org/factcast/core/FactStreamPositionTest.java
@@ -78,4 +78,31 @@ class FactStreamPositionTest {
       Assertions.assertThat(actual.serial()).isSameAs(-1L);
     }
   }
+
+  @Nested
+  class WhenIsAfter {
+
+    @Test
+    void isAfter() {
+      FactStreamPosition fsp = FactStreamPosition.of(UUID.randomUUID(), 42);
+      assertTrue(FactStreamPosition.of(UUID.randomUUID(), 43).isAfter(fsp));
+    }
+
+    @Test
+    void isAfterNull() {
+      assertTrue(FactStreamPosition.of(UUID.randomUUID(), 43).isAfter(null));
+    }
+
+    @Test
+    void isNotAfter() {
+      FactStreamPosition fsp = FactStreamPosition.of(UUID.randomUUID(), 42);
+      assertFalse(FactStreamPosition.of(UUID.randomUUID(), 41).isAfter(fsp));
+    }
+
+    @Test
+    void isEqual() {
+      FactStreamPosition fsp = FactStreamPosition.of(UUID.randomUUID(), 42);
+      assertFalse(fsp.isAfter(fsp));
+    }
+  }
 }

--- a/factcast-core/src/test/java/org/factcast/core/TestFact.java
+++ b/factcast-core/src/test/java/org/factcast/core/TestFact.java
@@ -22,7 +22,6 @@ import lombok.*;
 import org.factcast.core.util.FactCastJson;
 
 @AllArgsConstructor
-@NoArgsConstructor
 @Getter
 @Setter
 @EqualsAndHashCode(of = "id")
@@ -44,6 +43,10 @@ public class TestFact implements Fact {
   String jsonPayload = "{}";
 
   Map<String, String> meta = new HashMap<>();
+
+  public TestFact() {
+    meta("_ser", String.valueOf(this.serial));
+  }
 
   @Override
   public String meta(String key) {

--- a/factcast-factus/src/main/java/org/factcast/factus/FactusImpl.java
+++ b/factcast-factus/src/main/java/org/factcast/factus/FactusImpl.java
@@ -234,7 +234,9 @@ public class FactusImpl implements Factus {
 
           @Override
           public void onFastForward(@NonNull FactStreamPosition factIdToFfwdTo) {
-            subscribedProjection.factStreamPosition(factIdToFfwdTo);
+            if (factIdToFfwdTo.isAfter(lastPositionApplied)) {
+              subscribedProjection.factStreamPosition(factIdToFfwdTo);
+            }
           }
         };
 
@@ -395,13 +397,16 @@ public class FactusImpl implements Factus {
           @Override
           public void onFastForward(@NonNull FactStreamPosition factIdToFfwdTo) {
             flush();
-            if (projection instanceof FactStreamPositionAware) {
-              ((FactStreamPositionAware) projection).factStreamPosition(factIdToFfwdTo);
-            }
 
-            // only persist ffwd if we ever had a state or applied facts in this catchup
-            if (stateOrNull != null || positionOfLastFactApplied.get() != null) {
-              positionOfLastFactApplied.set(factIdToFfwdTo);
+            if (factIdToFfwdTo.isAfter(positionOfLastFactApplied.get())) {
+              if (projection instanceof FactStreamPositionAware) {
+                ((FactStreamPositionAware) projection).factStreamPosition(factIdToFfwdTo);
+              }
+
+              // only persist ffwd if we ever had a state or applied facts in this catchup
+              if (stateOrNull != null) {
+                positionOfLastFactApplied.set(factIdToFfwdTo);
+              }
             }
           }
         };

--- a/factcast-factus/src/main/java/org/factcast/factus/FactusImpl.java
+++ b/factcast-factus/src/main/java/org/factcast/factus/FactusImpl.java
@@ -398,13 +398,14 @@ public class FactusImpl implements Factus {
           public void onFastForward(@NonNull FactStreamPosition factIdToFfwdTo) {
             flush();
 
-            if (factIdToFfwdTo.isAfter(positionOfLastFactApplied.get())) {
+            FactStreamPosition factStreamPosition = positionOfLastFactApplied.get();
+            if (factIdToFfwdTo.isAfter(factStreamPosition)) {
               if (projection instanceof FactStreamPositionAware) {
                 ((FactStreamPositionAware) projection).factStreamPosition(factIdToFfwdTo);
               }
 
               // only persist ffwd if we ever had a state or applied facts in this catchup
-              if (stateOrNull != null) {
+              if (stateOrNull != null || factStreamPosition != null) {
                 positionOfLastFactApplied.set(factIdToFfwdTo);
               }
             }

--- a/factcast-factus/src/test/java/org/factcast/factus/FactusImplTest.java
+++ b/factcast-factus/src/test/java/org/factcast/factus/FactusImplTest.java
@@ -821,6 +821,58 @@ class FactusImplTest {
     }
 
     @Test
+    void ignoresFastForwardIfBehindConsumedFact() {
+      // INIT
+      SubscribedProjection subscribedProjection = mock(SubscribedProjection.class);
+      Projector<SubscribedProjection> eventApplier = mock(Projector.class);
+
+      when(subscribedProjection.acquireWriteToken(any())).thenReturn(() -> {});
+
+      when(ehFactory.create(subscribedProjection)).thenReturn(eventApplier);
+
+      when(eventApplier.createFactSpecs())
+          .thenReturn(Collections.singletonList(mock(FactSpec.class)));
+      doAnswer(
+              i -> {
+                Fact argument = Iterables.getLast((List<Fact>) (i.getArgument(0)));
+                subscribedProjection.factStreamPosition(FactStreamPosition.from(argument));
+                return null;
+              })
+          .when(eventApplier)
+          .apply(any(List.class));
+
+      Subscription subscription = mock(Subscription.class);
+      when(fc.subscribe(any(), any())).thenReturn(subscription);
+
+      // RUN
+      underTest.subscribeAndBlock(subscribedProjection);
+
+      // ASSERT
+      verify(subscribedProjection).acquireWriteToken(retryWaitTime.capture());
+      assertThat(retryWaitTime.getValue()).isEqualTo(Duration.ofMinutes(5));
+
+      verify(fc).subscribe(any(), factObserverArgumentCaptor.capture());
+
+      FactObserver factObserver = factObserverArgumentCaptor.getValue();
+
+      UUID factId = randomUUID();
+      Fact mockedFact = Fact.builder().id(factId).serial(12L).buildWithoutPayload();
+      FactStreamPosition ffwdPosition = FactStreamPosition.of(UUID.randomUUID(), 10L);
+
+      // onNext(...)
+      // now assume a new fact has been observed...
+      factObserver.onNext(mockedFact);
+      factObserver.flush();
+      // ... and the fact stream position should be updated as well
+      verify(subscribedProjection).factStreamPosition(FactStreamPosition.of(factId, 12));
+      ;
+
+      factObserver.onFastForward(ffwdPosition);
+
+      verify(subscribedProjection, never()).factStreamPosition(ffwdPosition);
+    }
+
+    @Test
     void subscribeWithCustomRetryWaitTime() {
       // INIT
       SubscribedProjection subscribedProjection = mock(SubscribedProjection.class);
@@ -1200,6 +1252,34 @@ class FactusImplTest {
           .thenAnswer(
               i -> {
                 FactObserver fo = i.getArgument(1);
+                fo.onFastForward(pos);
+                return sub;
+              });
+      when(pro.createFactSpecs()).thenReturn(Lists.newArrayList(spec1));
+
+      SomeSnapshotProjection p = new SomeSnapshotProjection();
+      UUID ret = underTest.catchupProjection(p, UUID.randomUUID(), null);
+
+      Assertions.assertThat(ret).isNotNull().isEqualTo(id);
+    }
+
+    @Test
+    @SneakyThrows
+    void ignoresFastForwardIfBeforeConsumedFact() {
+      Projector pro = mock(Projector.class);
+      Subscription sub = mock(Subscription.class);
+      FactSpec spec1 = FactSpec.from(NameEvent.class);
+
+      Fact f = new TestFact();
+      UUID id = f.id();
+      FactStreamPosition pos = FactStreamPosition.of(UUID.randomUUID(), 41L);
+
+      when(ehFactory.create(any())).thenReturn(pro);
+      when(fc.subscribe(any(SubscriptionRequest.class), any(FactObserver.class)))
+          .thenAnswer(
+              i -> {
+                FactObserver fo = i.getArgument(1);
+                fo.onNext(f);
                 fo.onFastForward(pos);
                 return sub;
               });

--- a/factcast-factus/src/test/java/org/factcast/factus/FactusImplTest.java
+++ b/factcast-factus/src/test/java/org/factcast/factus/FactusImplTest.java
@@ -865,7 +865,6 @@ class FactusImplTest {
       factObserver.flush();
       // ... and the fact stream position should be updated as well
       verify(subscribedProjection).factStreamPosition(FactStreamPosition.of(factId, 12));
-      ;
 
       factObserver.onFastForward(ffwdPosition);
 

--- a/factcast-store/src/main/java/org/factcast/store/internal/PgFactStream.java
+++ b/factcast-store/src/main/java/org/factcast/store/internal/PgFactStream.java
@@ -118,7 +118,7 @@ public class PgFactStream {
       catchup();
     }
 
-    fastForward(request, serial);
+    fastForward(request);
 
     // propagate catchup
     if (isConnected()) {
@@ -168,7 +168,7 @@ public class PgFactStream {
   }
 
   @VisibleForTesting
-  void fastForward(SubscriptionRequest request, AtomicLong serial) {
+  void fastForward(SubscriptionRequest request) {
     if (isConnected()) {
 
       long startedSer = 0;

--- a/factcast-store/src/main/java/org/factcast/store/internal/PgFactStream.java
+++ b/factcast-store/src/main/java/org/factcast/store/internal/PgFactStream.java
@@ -118,7 +118,7 @@ public class PgFactStream {
       catchup();
     }
 
-    fastForward(request);
+    fastForward(request, serial);
 
     // propagate catchup
     if (isConnected()) {
@@ -168,7 +168,7 @@ public class PgFactStream {
   }
 
   @VisibleForTesting
-  void fastForward(SubscriptionRequest request) {
+  void fastForward(SubscriptionRequest request, AtomicLong serial) {
     if (isConnected()) {
 
       long startedSer = 0;
@@ -182,7 +182,7 @@ public class PgFactStream {
       UUID targetId = ffwdTarget.targetId();
       long targetSer = ffwdTarget.targetSer();
 
-      if (targetId != null && (targetSer > startedSer)) {
+      if (targetId != null && (targetSer > startedSer) && serial.get() < targetSer) {
         pipeline.process(Signal.of(FactStreamPosition.of(targetId, targetSer)));
       }
     }

--- a/factcast-store/src/test/java/org/factcast/store/internal/PgFactStreamTest.java
+++ b/factcast-store/src/test/java/org/factcast/store/internal/PgFactStreamTest.java
@@ -114,18 +114,18 @@ public class PgFactStreamTest {
     void noFfwdNotConnected() {
 
       underTest.close();
-      underTest.fastForward(request);
+      underTest.fastForward(request, serial);
 
-      verifyNoInteractions(subscription);
+      verifyNoInteractions(pipeline);
     }
 
     @Test
     void noFfwdFromScratch() {
       when(request.startingAfter()).thenReturn(Optional.empty());
 
-      underTest.fastForward(request);
+      underTest.fastForward(request, serial);
 
-      verifyNoInteractions(subscription);
+      verifyNoInteractions(pipeline);
     }
 
     @Test
@@ -135,9 +135,9 @@ public class PgFactStreamTest {
       when(idToSerMapper.retrieve(uuid)).thenReturn(10L);
       when(ffwdTarget.targetId()).thenReturn(null);
 
-      underTest.fastForward(request);
+      underTest.fastForward(request, serial);
 
-      verifyNoInteractions(subscription);
+      verifyNoInteractions(pipeline);
     }
 
     @Test
@@ -149,7 +149,7 @@ public class PgFactStreamTest {
       when(ffwdTarget.targetId()).thenReturn(target.factId());
       when(ffwdTarget.targetSer()).thenReturn(target.serial());
 
-      underTest.fastForward(request);
+      underTest.fastForward(request, serial);
 
       verify(pipeline).process(Signal.of(target));
     }
@@ -162,9 +162,22 @@ public class PgFactStreamTest {
       when(ffwdTarget.targetId()).thenReturn(UUID.randomUUID());
       when(ffwdTarget.targetSer()).thenReturn(9L);
 
-      underTest.fastForward(request);
+      underTest.fastForward(request, serial);
 
-      verifyNoInteractions(subscription);
+      verifyNoInteractions(pipeline);
+    }
+
+    @Test
+    void noFfwdIfTargetBehindConsumed() {
+      UUID uuid = UUID.randomUUID();
+      when(request.startingAfter()).thenReturn(Optional.empty());
+      when(ffwdTarget.targetId()).thenReturn(UUID.randomUUID());
+      when(ffwdTarget.targetSer()).thenReturn(5L);
+      when(serial.get()).thenReturn(6L);
+
+      underTest.fastForward(request, serial);
+
+      verifyNoInteractions(pipeline);
     }
 
     @Test
@@ -176,7 +189,7 @@ public class PgFactStreamTest {
       when(ffwdTarget.targetId()).thenReturn(target.factId());
       when(ffwdTarget.targetSer()).thenReturn(target.serial());
 
-      underTest.fastForward(request);
+      underTest.fastForward(request, serial);
 
       verify(pipeline).process(Signal.of(target));
     }

--- a/factcast-store/src/test/java/org/factcast/store/internal/PgFactStreamTest.java
+++ b/factcast-store/src/test/java/org/factcast/store/internal/PgFactStreamTest.java
@@ -114,7 +114,7 @@ public class PgFactStreamTest {
     void noFfwdNotConnected() {
 
       underTest.close();
-      underTest.fastForward(request, serial);
+      underTest.fastForward(request);
 
       verifyNoInteractions(pipeline);
     }
@@ -123,7 +123,7 @@ public class PgFactStreamTest {
     void noFfwdFromScratch() {
       when(request.startingAfter()).thenReturn(Optional.empty());
 
-      underTest.fastForward(request, serial);
+      underTest.fastForward(request);
 
       verifyNoInteractions(pipeline);
     }
@@ -135,7 +135,7 @@ public class PgFactStreamTest {
       when(idToSerMapper.retrieve(uuid)).thenReturn(10L);
       when(ffwdTarget.targetId()).thenReturn(null);
 
-      underTest.fastForward(request, serial);
+      underTest.fastForward(request);
 
       verifyNoInteractions(pipeline);
     }
@@ -149,7 +149,7 @@ public class PgFactStreamTest {
       when(ffwdTarget.targetId()).thenReturn(target.factId());
       when(ffwdTarget.targetSer()).thenReturn(target.serial());
 
-      underTest.fastForward(request, serial);
+      underTest.fastForward(request);
 
       verify(pipeline).process(Signal.of(target));
     }
@@ -162,7 +162,7 @@ public class PgFactStreamTest {
       when(ffwdTarget.targetId()).thenReturn(UUID.randomUUID());
       when(ffwdTarget.targetSer()).thenReturn(9L);
 
-      underTest.fastForward(request, serial);
+      underTest.fastForward(request);
 
       verifyNoInteractions(pipeline);
     }
@@ -173,9 +173,9 @@ public class PgFactStreamTest {
       when(request.startingAfter()).thenReturn(Optional.empty());
       when(ffwdTarget.targetId()).thenReturn(UUID.randomUUID());
       when(ffwdTarget.targetSer()).thenReturn(5L);
-      when(serial.get()).thenReturn(6L);
+      underTest.serial().set(6);
 
-      underTest.fastForward(request, serial);
+      underTest.fastForward(request);
 
       verifyNoInteractions(pipeline);
     }
@@ -189,7 +189,7 @@ public class PgFactStreamTest {
       when(ffwdTarget.targetId()).thenReturn(target.factId());
       when(ffwdTarget.targetSer()).thenReturn(target.serial());
 
-      underTest.fastForward(request, serial);
+      underTest.fastForward(request);
 
       verify(pipeline).process(Signal.of(target));
     }


### PR DESCRIPTION
- ignore stale ffwd in factus
- only send ffwd if its really a forward

closes #3289 