### PR TITLE
[0.8.3-release] #3289: FastForward information might be stale but is still applied client-side

### DIFF
--- a/factcast-core/src/main/java/org/factcast/core/FactStreamPosition.java
+++ b/factcast-core/src/main/java/org/factcast/core/FactStreamPosition.java
@@ -43,4 +43,15 @@ public class FactStreamPosition {
     if (uuid == null) return null;
     else return FactStreamPosition.of(uuid, -1L);
   }
+
+  /**
+   * Checks if fsp is after the current one. Its considered being after if the `factStreamPosition`
+   * is null (no FSP yet) or when the serial of the current FSP is greater than the one given.
+   *
+   * @param factStreamPosition
+   * @return
+   */
+  public boolean isAfter(@Nullable FactStreamPosition factStreamPosition) {
+    return factStreamPosition == null || serial > factStreamPosition.serial();
+  }
 }

--- a/factcast-core/src/test/java/org/factcast/core/FactStreamPositionTest.java
+++ b/factcast-core/src/test/java/org/factcast/core/FactStreamPositionTest.java
@@ -78,4 +78,31 @@ class FactStreamPositionTest {
       Assertions.assertThat(actual.serial()).isSameAs(-1L);
     }
   }
+
+  @Nested
+  class WhenIsAfter {
+
+    @Test
+    void isAfter() {
+      FactStreamPosition fsp = FactStreamPosition.of(UUID.randomUUID(), 42);
+      assertTrue(FactStreamPosition.of(UUID.randomUUID(), 43).isAfter(fsp));
+    }
+
+    @Test
+    void isAfterNull() {
+      assertTrue(FactStreamPosition.of(UUID.randomUUID(), 43).isAfter(null));
+    }
+
+    @Test
+    void isNotAfter() {
+      FactStreamPosition fsp = FactStreamPosition.of(UUID.randomUUID(), 42);
+      assertFalse(FactStreamPosition.of(UUID.randomUUID(), 41).isAfter(fsp));
+    }
+
+    @Test
+    void isEqual() {
+      FactStreamPosition fsp = FactStreamPosition.of(UUID.randomUUID(), 42);
+      assertFalse(fsp.isAfter(fsp));
+    }
+  }
 }

--- a/factcast-core/src/test/java/org/factcast/core/TestFact.java
+++ b/factcast-core/src/test/java/org/factcast/core/TestFact.java
@@ -22,7 +22,6 @@ import lombok.*;
 import org.factcast.core.util.FactCastJson;
 
 @AllArgsConstructor
-@NoArgsConstructor
 @Getter
 @Setter
 @EqualsAndHashCode(of = "id")
@@ -44,6 +43,10 @@ public class TestFact implements Fact {
   String jsonPayload = "{}";
 
   Map<String, String> meta = new HashMap<>();
+
+  public TestFact() {
+    meta("_ser", String.valueOf(this.serial));
+  }
 
   @Override
   public String meta(String key) {

--- a/factcast-factus/src/test/java/org/factcast/factus/FactusImplTest.java
+++ b/factcast-factus/src/test/java/org/factcast/factus/FactusImplTest.java
@@ -822,6 +822,57 @@ class FactusImplTest {
     }
 
     @Test
+    void ignoresFastForwardIfBehindConsumedFact() {
+      // INIT
+      SubscribedProjection subscribedProjection = mock(SubscribedProjection.class);
+      Projector<SubscribedProjection> eventApplier = mock(Projector.class);
+
+      when(subscribedProjection.acquireWriteToken(any())).thenReturn(() -> {});
+
+      when(ehFactory.create(subscribedProjection)).thenReturn(eventApplier);
+
+      when(eventApplier.createFactSpecs())
+          .thenReturn(Collections.singletonList(mock(FactSpec.class)));
+      doAnswer(
+              i -> {
+                Fact argument = Iterables.getLast((List<Fact>) (i.getArgument(0)));
+                subscribedProjection.factStreamPosition(FactStreamPosition.from(argument));
+                return null;
+              })
+          .when(eventApplier)
+          .apply(any(List.class));
+
+      Subscription subscription = mock(Subscription.class);
+      when(fc.subscribe(any(), any())).thenReturn(subscription);
+
+      // RUN
+      underTest.subscribeAndBlock(subscribedProjection);
+
+      // ASSERT
+      verify(subscribedProjection).acquireWriteToken(retryWaitTime.capture());
+      assertThat(retryWaitTime.getValue()).isEqualTo(Duration.ofMinutes(5));
+
+      verify(fc).subscribe(any(), factObserverArgumentCaptor.capture());
+
+      FactObserver factObserver = factObserverArgumentCaptor.getValue();
+
+      UUID factId = randomUUID();
+      Fact mockedFact = Fact.builder().id(factId).serial(12L).buildWithoutPayload();
+      FactStreamPosition ffwdPosition = FactStreamPosition.of(UUID.randomUUID(), 10L);
+
+      // onNext(...)
+      // now assume a new fact has been observed...
+      factObserver.onNext(mockedFact);
+      factObserver.flush();
+      // ... and the fact stream position should be updated as well
+      verify(subscribedProjection).factStreamPosition(FactStreamPosition.of(factId, 12));
+
+      factObserver.onFastForward(ffwdPosition);
+
+      verify(subscribedProjection, never()).factStreamPosition(ffwdPosition);
+    }
+
+    @Test
     void subscribeWithCustomRetryWaitTime() {
       // INIT
       SubscribedProjection subscribedProjection = mock(SubscribedProjection.class);
@@ -1201,6 +1252,34 @@ class FactusImplTest {
           .thenAnswer(
               i -> {
                 FactObserver fo = i.getArgument(1);
+                fo.onFastForward(pos);
+                return sub;
+              });
+      when(pro.createFactSpecs()).thenReturn(Lists.newArrayList(spec1));
+
+      SomeSnapshotProjection p = new SomeSnapshotProjection();
+      UUID ret = underTest.catchupProjection(p, UUID.randomUUID(), null);
+
+      Assertions.assertThat(ret).isNotNull().isEqualTo(id);
+    }
+
+    @Test
+    @SneakyThrows
+    void ignoresFastForwardIfBeforeConsumedFact() {
+      Projector pro = mock(Projector.class);
+      Subscription sub = mock(Subscription.class);
+      FactSpec spec1 = FactSpec.from(NameEvent.class);
+
+      Fact f = new TestFact();
+      UUID id = f.id();
+      FactStreamPosition pos = FactStreamPosition.of(UUID.randomUUID(), 41L);
+
+      when(ehFactory.create(any())).thenReturn(pro);
+      when(fc.subscribe(any(SubscriptionRequest.class), any(FactObserver.class)))
+          .thenAnswer(
+              i -> {
+                FactObserver fo = i.getArgument(1);
+                fo.onNext(f);
                 fo.onFastForward(pos);
                 return sub;
               });

--- a/factcast-store/src/main/java/org/factcast/store/internal/PgFactStream.java
+++ b/factcast-store/src/main/java/org/factcast/store/internal/PgFactStream.java
@@ -182,7 +182,7 @@ public class PgFactStream {
       UUID targetId = ffwdTarget.targetId();
       long targetSer = ffwdTarget.targetSer();
 
-      if (targetId != null && (targetSer > startedSer)) {
+      if (targetId != null && (targetSer > startedSer) && serial.get() < targetSer) {
         pipeline.process(Signal.of(FactStreamPosition.of(targetId, targetSer)));
       }
     }

--- a/factcast-store/src/test/java/org/factcast/store/internal/PgFactStreamTest.java
+++ b/factcast-store/src/test/java/org/factcast/store/internal/PgFactStreamTest.java
@@ -116,7 +116,7 @@ public class PgFactStreamTest {
       underTest.close();
       underTest.fastForward(request);
 
-      verifyNoInteractions(subscription);
+      verifyNoInteractions(pipeline);
     }
 
     @Test
@@ -125,7 +125,7 @@ public class PgFactStreamTest {
 
       underTest.fastForward(request);
 
-      verifyNoInteractions(subscription);
+      verifyNoInteractions(pipeline);
     }
 
     @Test
@@ -137,7 +137,7 @@ public class PgFactStreamTest {
 
       underTest.fastForward(request);
 
-      verifyNoInteractions(subscription);
+      verifyNoInteractions(pipeline);
     }
 
     @Test
@@ -164,7 +164,20 @@ public class PgFactStreamTest {
 
       underTest.fastForward(request);
 
-      verifyNoInteractions(subscription);
+      verifyNoInteractions(pipeline);
+    }
+
+    @Test
+    void noFfwdIfTargetBehindConsumed() {
+      UUID uuid = UUID.randomUUID();
+      when(request.startingAfter()).thenReturn(Optional.empty());
+      when(ffwdTarget.targetId()).thenReturn(UUID.randomUUID());
+      when(ffwdTarget.targetSer()).thenReturn(5L);
+      underTest.serial().set(6);
+
+      underTest.fastForward(request);
+
+      verifyNoInteractions(pipeline);
     }
 
     @Test


### PR DESCRIPTION
**Backport:** https://github.com/factcast/factcast/pull/3291

- ignore stale ffwd in factus
- only send ffwd if its really a forward

closes #3289 