### PR TITLE
#3361: do not throw for parallel update calls of tx redis projections on same instance

### DIFF
--- a/factcast-factus-redis/src/main/java/org/factcast/factus/redis/tx/AbstractRedisTxProjection.java
+++ b/factcast-factus-redis/src/main/java/org/factcast/factus/redis/tx/AbstractRedisTxProjection.java
@@ -16,11 +16,9 @@
 package org.factcast.factus.redis.tx;
 
 import com.google.common.annotations.VisibleForTesting;
-import java.time.Duration;
 import lombok.NonNull;
 import lombok.experimental.Delegate;
 import org.factcast.core.FactStreamPosition;
-import org.factcast.factus.projection.WriterToken;
 import org.factcast.factus.projection.tx.OpenTransactionAware;
 import org.factcast.factus.projection.tx.TransactionBehavior;
 import org.factcast.factus.redis.AbstractRedisProjection;
@@ -48,17 +46,5 @@ abstract class AbstractRedisTxProjection extends AbstractRedisProjection
   public void transactionalFactStreamPosition(@NonNull FactStreamPosition position) {
     assertInTransaction();
     stateBucket(runningTransaction()).set(position);
-  }
-
-  @Override
-  public WriterToken acquireWriteToken(@NonNull Duration maxWait) {
-    assertNoRunningTransaction();
-    return super.acquireWriteToken(maxWait);
-  }
-
-  @Override
-  public AutoCloseable acquireWriteToken() {
-    assertNoRunningTransaction();
-    return super.acquireWriteToken();
   }
 }

--- a/factcast-itests/factcast-itests-factus/src/test/java/org/factcast/itests/factus/client/FactusClientTest.java
+++ b/factcast-itests/factcast-itests-factus/src/test/java/org/factcast/itests/factus/client/FactusClientTest.java
@@ -771,7 +771,7 @@ class FactusClientTest extends AbstractFactCastIntegrationTest {
   }
 
   @Test
-  void testParallelUpdateCallsForRedisTxManaged() {
+  void testParallelUpdateCallsForRedisTxProjections() {
     final var blockingRedisManagedUserNames = new BlockingRedisTxManagedUserNames(redissonClient);
     factus.publish(new UserCreated("John"));
 

--- a/factcast-itests/factcast-itests-factus/src/test/java/org/factcast/itests/factus/client/FactusClientTest.java
+++ b/factcast-itests/factcast-itests-factus/src/test/java/org/factcast/itests/factus/client/FactusClientTest.java
@@ -799,7 +799,7 @@ class FactusClientTest extends AbstractFactCastIntegrationTest {
             });
 
     assertThat(u1.thenCombine(u2, (b1, b2) -> b1 && b2))
-        .succeedsWithin(Duration.ofSeconds(1))
+        .succeedsWithin(Duration.ofSeconds(5))
         .isEqualTo(true);
   }
 

--- a/factcast-itests/factcast-itests-factus/src/test/java/org/factcast/itests/factus/client/FactusClientTest.java
+++ b/factcast-itests/factcast-itests-factus/src/test/java/org/factcast/itests/factus/client/FactusClientTest.java
@@ -803,11 +803,8 @@ class FactusClientTest extends AbstractFactCastIntegrationTest {
         .isEqualTo(true);
   }
 
+  @SneakyThrows
   private static void sleep(long ms) {
-    try {
-      Thread.sleep(ms);
-    } catch (InterruptedException e) {
-      // does not matter
-    }
+    Thread.sleep(ms);
   }
 }

--- a/factcast-itests/factcast-itests-factus/src/test/java/org/factcast/itests/factus/proj/BlockingRedisTxManagedUserNames.java
+++ b/factcast-itests/factcast-itests-factus/src/test/java/org/factcast/itests/factus/proj/BlockingRedisTxManagedUserNames.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2017-2025 factcast.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.factcast.itests.factus.proj;
+
+import lombok.*;
+import lombok.extern.slf4j.Slf4j;
+import org.factcast.factus.Handler;
+import org.factcast.factus.redis.tx.AbstractRedisTxManagedProjection;
+import org.factcast.factus.serializer.ProjectionMetaData;
+import org.factcast.itests.factus.event.UserCreated;
+import org.redisson.api.*;
+
+@Slf4j
+@ProjectionMetaData(revision = 1)
+public class BlockingRedisTxManagedUserNames extends AbstractRedisTxManagedProjection {
+
+  public BlockingRedisTxManagedUserNames(RedissonClient redisson) {
+    super(redisson);
+  }
+
+  @SneakyThrows
+  @Handler
+  public void apply(UserCreated created) {
+    log.info("BlockingRedisManagedUserNames:apply");
+    Thread.sleep(500);
+  }
+}


### PR DESCRIPTION
We already rely on the redis lock to make sure we dont run multiple updates in parallel (across several instances). When we remove the assertion of the running tx the same applies then to multiple update calls for the same jvm/spring context/projection instance.

closes #3361 