### PR TITLE
Revert "fix(deps): update dependency org.apache.fury:fury-core to v0.10.0"

### DIFF
--- a/factcast-factus-serializer-fury/pom.xml
+++ b/factcast-factus-serializer-fury/pom.xml
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>org.apache.fury</groupId>
       <artifactId>fury-core</artifactId>
-      <version>0.10.0</version>
+      <version>0.9.0</version>
     </dependency>
     <dependency>
       <groupId>org.dom4j</groupId>

--- a/factcast-factus-serializer-fury/src/test/java/org/factcast/factus/serializer/fury/ComplexExampleTest.java
+++ b/factcast-factus-serializer-fury/src/test/java/org/factcast/factus/serializer/fury/ComplexExampleTest.java
@@ -15,6 +15,7 @@
  */
 package org.factcast.factus.serializer.fury;
 
+import com.google.common.collect.*;
 import java.util.*;
 import lombok.*;
 import org.apache.fury.*;
@@ -24,10 +25,10 @@ import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 
 class ComplexExampleTest {
 
-  final String serializedWithFury010 =
-      "Av9ZBEClKUTJc1A6JtFAKYgSnooBTpLUiRQBaMkjotI4FgT0TmPWS/SXAx6yAA50XKlB6us/eAAMAAHyCQAAuo5MABBuYXJmAF4ZGQsF/CxAlc0hQbNzrABCAQAANEVV9Ghvs4ilM5An+lc8uABGAQAAL0LyleDEBTjvxnyuBKxImgBEAQQBBxwE9E5j1kv0lwMesnOyoECuQbwbx1S4cwEqeSkvRA6jAPhAZCCcN3typya2rD+6dL8=";
+  final String serializedWithFury09 =
+      "Av9ZBEClKUTJc1A6JtFAKYgSnooBTpLUiRQBaMkjotI4FgT0TmPWS/SXAx6yAA50XKlB6us/eAAMAAHyCQAAuo5MABBuYXJmAF4ZGQsF/CxAlc0hQbNzrABCAQAAIU2gVobMH1ViK0Lc2ydLlwBGAQAAK0Nv7s4eE/DNeBdtAefurQBEAQB3T9jbViQWu1a/aj1Cg0SGAAccBPROY9ZL9JcDHrJzsqBAADJC0FgIJP/nI2neocJh7ak=";
   final String serializedWithJackson =
-      "{\"b\":true,\"s\":12,\"i\":623517,\"d\":0.872345763,\"l\":1273,\"c\":\"x\",\"txt\":\"narf\",\"list\":[{\"uuid\":\"88b36f68-f455-4534-b83c-57fa279033a5\"}],\"set\":[{\"uuid\":\"3805c4e0-95f2-422f-9a48-ac04ae7cc6ef\"}],\"map\":{\"73b854c7-1bbc-41ae-a30e-442f29792a01\":{\"uuid\":\"727b379c-2064-40f8-bf74-ba3facb626a7\"}},\"bd\":0.7235481762346872364823468}";
+      "{\"b\":true,\"s\":12,\"i\":623517,\"d\":0.872345763,\"l\":1273,\"c\":\"x\",\"txt\":\"narf\",\"list\":[{\"uuid\":\"551fcc86-56a0-4d21-974b-27dbdc422b62\"}],\"set\":[{\"uuid\":\"f0131ece-ee6f-432b-adee-e7016d1778cd\"}],\"map\":{\"bb162456-dbd8-4f77-8644-83423d6abf56\":{\"uuid\":\"e7ff2408-58d0-4232-a9ed-61c2a1de6923\"}},\"bd\":0.7235481762346872364823468}";
 
   @SneakyThrows
   @Test
@@ -35,7 +36,7 @@ class ComplexExampleTest {
     ThreadSafeFury fury = Fury.builder().requireClassRegistration(false).buildThreadSafeFury();
 
     ComplexExample exampleFromFury =
-        (ComplexExample) fury.deserialize(Base64.getDecoder().decode(serializedWithFury010));
+        (ComplexExample) fury.deserialize(Base64.getDecoder().decode(serializedWithFury09));
     String furyAsJson =
         new ObjectMapper().writerFor(ComplexExample.class).writeValueAsString(exampleFromFury);
 


### PR DESCRIPTION
Reverts factcast/factcast#3461

as the test shows (and is supposed to show), 0.10 is not compatible with versions before. we can only do this in a major release.