### PR TITLE
#3755: issue3755 disable fast updates

### DIFF
--- a/factcast-store/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/factcast-store/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -426,3 +426,21 @@ databaseChangeLog:
             relativeToChangelogFile: true
             splitStatements: false
             stripComments: true
+
+  - changeSet:
+      id: issue3755_disable_fast_update
+      runInTransaction: false
+      author: leflamm
+      preConditions:
+        - onFail: MARK_RAN
+        - sqlCheck:
+            expectedResult: t
+            sql: SELECT count_estimate('SELECT * FROM fact') < 10000000;
+      comment: Disable fast update for large GIN index; If you have less than 10mio facts, this will be executed, if not, we kindly ask you to execute this script manually
+      changes:
+        - sqlFile:
+            encoding: utf8
+            path: factcast/issue3755/disable_fast_update.sql
+            relativeToChangelogFile: true
+            splitStatements: false
+            stripComments: true

--- a/factcast-store/src/main/resources/db/changelog/factcast/issue3755/disable_fast_update.sql
+++ b/factcast-store/src/main/resources/db/changelog/factcast/issue3755/disable_fast_update.sql
@@ -1,0 +1,3 @@
+-- noinspection SqlNoDataSourceInspectionForFile
+
+ALTER INDEX idx_fact_header SET ( fastupdate = false )


### PR DESCRIPTION
The change will disable `fastupdate` on the large GIN index
* contains motivation and explanation
* happens automatically "on smaller setups" 
* asks for manual action for larger setups
