### PR TITLE
#4369 Fixing flaky test

### DIFF
--- a/factcast-store/src/test/java/org/factcast/store/registry/transformation/cache/PgTransformationCacheTest.java
+++ b/factcast-store/src/test/java/org/factcast/store/registry/transformation/cache/PgTransformationCacheTest.java
@@ -369,8 +369,6 @@ class PgTransformationCacheTest {
     @Test
     void doesNotCompactIfInReadOnlyMode() {
       when(storeConfigurationProperties.isReadOnlyModeEnabled()).thenReturn(true);
-      underTest.registerWrite(TransformationCache.Key.of(UUID.randomUUID(), 1, "someChainId"), f);
-      assertThat(underTest.buffer().size()).isOne();
 
       Mockito.reset(jdbcTemplate);
       underTest.compact(THRESHOLD_DATE);


### PR DESCRIPTION
The removed assert, calls an async method that flushes the buffer, cleaning it on the process. That is the intended behavior of the buffer and shouldnt be change; instead, removing it still gives a valid test for the intended use case (compacting) and removes the flakiness 