### PR TITLE
factcast-spring-boot-autoconfigure: consider *all* BinaryJacksonSnapshotSerializerCustomizer beans for snapshot serialization

### DIFF
--- a/factcast-spring-boot-autoconfigure/src/main/java/org/factcast/spring/boot/autoconfigure/factus/snapshot/serializer/binary/BinaryJacksonSnapshotSerializerAutoConfiguration.java
+++ b/factcast-spring-boot-autoconfigure/src/main/java/org/factcast/spring/boot/autoconfigure/factus/snapshot/serializer/binary/BinaryJacksonSnapshotSerializerAutoConfiguration.java
@@ -15,6 +15,7 @@
  */
 package org.factcast.spring.boot.autoconfigure.factus.snapshot.serializer.binary;
 
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.factcast.factus.serializer.SnapshotSerializer;
 import org.factcast.factus.serializer.binary.*;
@@ -34,8 +35,13 @@ public class BinaryJacksonSnapshotSerializerAutoConfiguration {
   @Bean
   @ConditionalOnMissingBean(SnapshotSerializer.class)
   public SnapshotSerializer snapshotSerializer(
-      BinaryJacksonSnapshotSerializerCustomizer customizer) {
-    return new CompressedBinaryJacksonSnapshotSerializer(customizer);
+      List<BinaryJacksonSnapshotSerializerCustomizer> customizers) {
+    return new CompressedBinaryJacksonSnapshotSerializer(
+        objectMapper -> {
+          for (var customizer : customizers) {
+            customizer.accept(objectMapper);
+          }
+        });
   }
 
   @Bean

--- a/factcast-spring-boot-autoconfigure/src/main/java/org/factcast/spring/boot/autoconfigure/factus/snapshot/serializer/binary/UncompressedBinaryJacksonSnapshotSerializerAutoConfiguration.java
+++ b/factcast-spring-boot-autoconfigure/src/main/java/org/factcast/spring/boot/autoconfigure/factus/snapshot/serializer/binary/UncompressedBinaryJacksonSnapshotSerializerAutoConfiguration.java
@@ -15,6 +15,7 @@
  */
 package org.factcast.spring.boot.autoconfigure.factus.snapshot.serializer.binary;
 
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.factcast.factus.serializer.SnapshotSerializer;
 import org.factcast.factus.serializer.binary.*;
@@ -35,8 +36,13 @@ public class UncompressedBinaryJacksonSnapshotSerializerAutoConfiguration {
   @Bean
   @ConditionalOnMissingBean(SnapshotSerializer.class)
   public SnapshotSerializer snapshotSerializer(
-      BinaryJacksonSnapshotSerializerCustomizer customizer) {
-    return new UncompressedBinaryJacksonSnapshotSerializer(customizer);
+      List<BinaryJacksonSnapshotSerializerCustomizer> customizers) {
+    return new UncompressedBinaryJacksonSnapshotSerializer(
+        objectMapper -> {
+          for (var customizer : customizers) {
+            customizer.accept(objectMapper);
+          }
+        });
   }
 
   @Bean


### PR DESCRIPTION
there's no apparent reason multiple customizers in the context need to be in competition
(except if one were to have several factcast/factus instances, but then one probably wouldn't use autoconfiguration anyway).

this change makes it so they aren't; instead it picks up *all* BinaryJacksonSnapshotSerializerCustomizer beans and combines them.
