### PR TITLE
#4862: fix async catchup with CachedRowSet and propagate unsupported …

### DIFF
--- a/factcast-client-grpc/src/test/java/org/factcast/client/grpc/ClientExceptionHelperTest.java
+++ b/factcast-client-grpc/src/test/java/org/factcast/client/grpc/ClientExceptionHelperTest.java
@@ -95,6 +95,12 @@ class ClientExceptionHelperTest {
     }
 
     @Test
+    void doesNotConsiderUnimplementedRetryable() {
+      StatusRuntimeException ex = new StatusRuntimeException(Status.UNIMPLEMENTED);
+      assertThat(ClientExceptionHelper.isRetryable(ex)).isFalse();
+    }
+
+    @Test
     void wrapsRetryableCancelledWithMessage() {
       StatusRuntimeException ex =
           new StatusRuntimeException(

--- a/factcast-server-grpc/src/main/java/org/factcast/server/grpc/ServerExceptionHelper.java
+++ b/factcast-server-grpc/src/main/java/org/factcast/server/grpc/ServerExceptionHelper.java
@@ -18,6 +18,7 @@ package org.factcast.server.grpc;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
+import java.sql.SQLFeatureNotSupportedException;
 import lombok.experimental.UtilityClass;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.security.core.AuthenticationException;
@@ -31,8 +32,9 @@ public class ServerExceptionHelper {
       return sre;
     } else if (e instanceof RuntimeException && e.getClass().getName().startsWith("org.factcast")) {
       return new StatusRuntimeException(Status.UNKNOWN, addMetaData(meta, e));
-    } else if (e instanceof UnsupportedOperationException) {
-      // UNIMPLEMENTED is technically not fully correct but best we can do here
+    } else if (e instanceof UnsupportedOperationException
+        || e instanceof SQLFeatureNotSupportedException) {
+      // UNIMPLEMENTED is technically not really correct, but seems to be the closest option
       return new StatusRuntimeException(Status.UNIMPLEMENTED, meta);
     } else if (e instanceof AuthenticationException) {
       if (e instanceof AuthenticationCredentialsNotFoundException) {

--- a/factcast-server-grpc/src/main/java/org/factcast/server/grpc/ServerExceptionHelper.java
+++ b/factcast-server-grpc/src/main/java/org/factcast/server/grpc/ServerExceptionHelper.java
@@ -34,7 +34,7 @@ public class ServerExceptionHelper {
       return new StatusRuntimeException(Status.UNKNOWN, addMetaData(meta, e));
     } else if (e instanceof UnsupportedOperationException
         || e instanceof SQLFeatureNotSupportedException) {
-      // UNIMPLEMENTED is technically not really correct, but seems to be the closest option
+      // UNIMPLEMENTED is technically not fully correct but best we can do here
       return new StatusRuntimeException(Status.UNIMPLEMENTED, meta);
     } else if (e instanceof AuthenticationException) {
       if (e instanceof AuthenticationCredentialsNotFoundException) {

--- a/factcast-server-grpc/src/test/java/org/factcast/server/grpc/GrpcObserverAdapterTest.java
+++ b/factcast-server-grpc/src/test/java/org/factcast/server/grpc/GrpcObserverAdapterTest.java
@@ -23,9 +23,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 import io.micrometer.core.instrument.Tags;
 import java.nio.charset.StandardCharsets;
+import java.sql.SQLFeatureNotSupportedException;
 import lombok.NonNull;
 import org.assertj.core.api.Assertions;
 import org.factcast.core.Fact;
@@ -146,6 +149,21 @@ class GrpcObserverAdapterTest {
     uut.onError(exception);
     verify(observer).onError(any());
     verify(serverExceptionLogger).log(exception, "foo");
+  }
+
+  @Test
+  void sendsUnsupportedJdbcFeatureAsUnimplemented() {
+    GrpcObserverAdapter uut = new GrpcObserverAdapter("foo", observer, serverExceptionLogger);
+    var exception = new SQLFeatureNotSupportedException("Operation not yet supported");
+    ArgumentCaptor<Throwable> error = ArgumentCaptor.forClass(Throwable.class);
+
+    uut.onError(exception);
+
+    verify(observer).onError(error.capture());
+    assertThat(error.getValue())
+        .isInstanceOf(StatusRuntimeException.class)
+        .extracting(e -> ((StatusRuntimeException) e).getStatus().getCode())
+        .isEqualTo(Status.Code.UNIMPLEMENTED);
   }
 
   @Test

--- a/factcast-store/src/main/java/org/factcast/store/internal/catchup/cursor/PgCursorCatchup.java
+++ b/factcast-store/src/main/java/org/factcast/store/internal/catchup/cursor/PgCursorCatchup.java
@@ -103,7 +103,8 @@ public class PgCursorCatchup extends AbstractPgCatchup {
   RowCallbackHandler createRowCallbackHandler(PgFactExtractor extractor) {
     return rs -> {
       try {
-        if (statementHolder.wasCanceled() || rs.isClosed()) {
+        // PreFetchingQuery supplies a CachedRowSet, which does not support the isClosed() check
+        if (statementHolder.wasCanceled()) {
           return;
         }
 

--- a/factcast-store/src/test/java/org/factcast/store/internal/catchup/cursor/PgCursorCatchupTest.java
+++ b/factcast-store/src/test/java/org/factcast/store/internal/catchup/cursor/PgCursorCatchupTest.java
@@ -22,6 +22,7 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Timer;
 import java.sql.*;
 import java.util.concurrent.atomic.*;
+import javax.sql.rowset.*;
 import lombok.SneakyThrows;
 import org.factcast.core.subscription.*;
 import org.factcast.store.StoreConfigurationProperties;
@@ -124,6 +125,19 @@ class PgCursorCatchupTest {
 
     @SneakyThrows
     @Test
+    void passesFactFromCachedRowSet() {
+      final var cbh = underTest.createRowCallbackHandler(extractor);
+      CachedRowSet rs = RowSetProvider.newFactory().createCachedRowSet();
+      PgFact testFact = mock(PgFact.class);
+      when(extractor.mapRow(rs, 0)).thenReturn(testFact);
+
+      cbh.processRow(rs);
+
+      verify(pipeline).process(Signal.of(testFact));
+    }
+
+    @SneakyThrows
+    @Test
     void passesFactEscalatesException() {
       final var cbh = underTest.createRowCallbackHandler(extractor);
       ResultSet rs = mock(ResultSet.class);
@@ -163,8 +177,6 @@ class PgCursorCatchupTest {
     void throwsWhenNotCanceled() {
       final var cbh = underTest.createRowCallbackHandler(new PgFactExtractor(new AtomicLong()));
       ResultSet rs = mock(ResultSet.class);
-      // it should appear open,
-      when(rs.isClosed()).thenReturn(false);
       // until
       PSQLException mockException =
           mock(PSQLException.class, withSettings().strictness(Strictness.LENIENT));
@@ -178,8 +190,6 @@ class PgCursorCatchupTest {
     void throwsWhenCanceledButUnexpectedException() {
       final var cbh = underTest.createRowCallbackHandler(extractor);
       ResultSet rs = mock(ResultSet.class);
-      // it should appear open,
-      when(rs.isClosed()).thenReturn(false);
       // until
       when(extractor.mapRow(any(), anyInt())).thenThrow(RuntimeException.class);
 


### PR DESCRIPTION
- removed the `ResultSet.isClosed()` check from `PgCursorCatchup`, because async fetching supplies a `CachedRowSet` that does not support this method, kept the existing statement-cancellation check to stop processing canceled subscriptions
- clients consider "UNKNOWN" retryable, causing resilient subscriptions to reconnect instead of reporting the error immediately, mapped `SQLFeatureNotSupportedException` to "UNIMPLEMENTED", which clients treat as non-retryable
