### PR TITLE
issue4883: fix flaky pipeline behaviour

### DIFF
--- a/factcast-schema-registry-cli/pom.xml
+++ b/factcast-schema-registry-cli/pom.xml
@@ -323,9 +323,15 @@
             <phase>integration-test</phase>
             <configuration>
               <executable>java</executable>
+              <!-- Runs off the reactor classpath instead of within repackaged jar,
+                since that would make the thin launcher resolve this module's parent POM
+                from the local/remote repository at runtime, which fails in any build that
+                did not "install" first (e.g. a bare "mvn verify"). -->
+              <classpathScope>runtime</classpathScope>
               <arguments>
-                <argument>-jar</argument>
-                <argument>target/fc-schema-cli.jar</argument>
+                <argument>-classpath</argument>
+                <classpath></classpath>
+                <argument>${main.class}</argument>
                 <argument>build</argument>
                 <argument>--base-path</argument>
                 <argument>../factcast-examples/factcast-example-schema-registry/src/main/resources</argument>


### PR DESCRIPTION
The origin of the issue is rooted in the combination of the `postgres-compatibility`  not executing a `install` but relying entirely on the cache in combination with the `factcast-schema-registry-cli` pom.xml defining `spring-boot-thin-layout`.

- When running the integration-test the thin jar requires its dependencies to be present in the ~/.m2, which entirely depends on the cache that was pulled by the job. 
- Since the `build` job (which executes `mvn install`) and `postgres-compatibility` run in parallel it will always restore the cache from a previous run - if this run does not contain the required artifacts it will fail (e.g. after a version bump).

Since the additionall install step probably was skipped to prevent the additional work I opted for executing the "flaky tests" based on the reactor classpath to be independent from the pulled cache.


Closes #4883 